### PR TITLE
Add vimspector to implementations list

### DIFF
--- a/_implementors/tools.md
+++ b/_implementors/tools.md
@@ -16,6 +16,7 @@ The following table lists the known development tools (IDEs) that implement the 
 | Eclipse IDE (LSP4E connector) | lsp4e.debug  | Eclipse    | [Eclipse community](https://projects.eclipse.org/projects/technology.lsp4e/who), [Eclipse LSP4E](https://projects.eclipse.org/projects/technology.lsp4e)
 | Emacs                         | emacs.dap-mode | [@yyoncho](https://github.com/yyoncho) | [dap-mode](https://github.com/yyoncho/dap-mode)
 | Theia                         | Theia        | Eclipse    | [theia](https://github.com/theia-ide/theia/)
+| Vim                           | vimspector   | [Ben Jackson](https://github.com/puremourning) | [vimspector](https://github.com/puremourning/vimspector), [vim](https://github.com/vim/vim)
 {: .table .table-bordered .table-responsive}
 
 The "client ID" is the identifier that a development tool sends to the debug adapter as part of the [**initialize**](../../specification#Requests_Initialize) request.


### PR DESCRIPTION
Vimspector implements the DAP and a debugging UI in Vim.

It's very much a work-in-progress, but it does work well enough that I use it myself :)