### PR TITLE
Support for register access

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ sectionid: changelog
 
 #### All notable changes to the specification will be documented in this file.
 
+* 1.35.x:
+  * Adds an optional `presentationHint` attribute to the `Scope` type which can be used to add semantic to the scope's contents. An example is to mark a scope as a "registers" scope that contains "registers" instead of variables.
+
 * 1.34.x:
   * Added support for data breakpoints via the 'dataBreakpointInfo' and 'setDataBreakpoints' requests and the 'supportsDataBreakpoints' capability.
   * Improved some comments.

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -2715,7 +2715,17 @@
 			"properties": {
 				"name": {
 					"type": "string",
-					"description": "Name of the scope such as 'Arguments', 'Locals'."
+					"description": "Name of the scope such as 'Arguments', 'Locals', or 'Registers'. This string is shown in the UI as is and can be translated."
+				},
+				"presentationHint": {
+					"type": "string",
+					"description": "An optional hint for how to present this scope in the UI. If this attribute is missing, the scope is shown with a generic UI.",
+					"_enum": [ "arguments", "locals", "registers" ],
+					"enumDescriptions": [
+						"Scope contains method arguments.",
+						"Scope contains local variables.",
+						"Scope contains registers. Only a single 'registers' scope should be returned from a 'scopes' request."
+					]
 				},
 				"variablesReference": {
 					"type": "integer",

--- a/specification.md
+++ b/specification.md
@@ -2636,9 +2636,19 @@ A Scope is a named container for variables. Optionally a scope can map to a sour
 ```typescript
 interface Scope {
   /**
-   * Name of the scope such as 'Arguments', 'Locals'.
+   * Name of the scope such as 'Arguments', 'Locals', or 'Registers'. This string is shown in the UI as is and can be translated.
    */
   name: string;
+
+  /**
+   * An optional hint for how to present this scope in the UI. If this attribute is missing, the scope is shown with a generic UI.
+   * Values: 
+   * 'arguments': Scope contains method arguments.
+   * 'locals': Scope contains local variables.
+   * 'registers': Scope contains registers. Only a single 'registers' scope should be returned from a 'scopes' request.
+   * etc.
+   */
+  presentationHint?: string;
 
   /**
    * The variables of this scope can be retrieved by passing the value of variablesReference to the VariablesRequest.


### PR DESCRIPTION
Based on Andrew's PR https://github.com/microsoft/vscode-debugadapter-node/pull/212 I've create a new PR for the DAP repo (where the truth lives).

While working on this, I noticed that the new "kind" attribute had a description using the term "hint". This made me think that "presentationHint" would be a better name than "kind" and more in line with the other UI related hints.

Use the "Github Pull Request" extension to conveniently review the changes from with the comfort of your VS Code workspace ;-)