### PR TITLE
Support for memory access and disassembly

### DIFF
--- a/_data/specification-toc.yml
+++ b/_data/specification-toc.yml
@@ -53,6 +53,8 @@
       anchor: Requests_Continue
     - title: DataBreakpointInfo
       anchor: Requests_DataBreakpointInfo
+    - title: Disassemble
+      anchor: Requests_Disassemble
     - title: Disconnect
       anchor: Requests_Disconnect
     - title: Evaluate
@@ -75,6 +77,8 @@
       anchor: Requests_Next
     - title: Pause
       anchor: Requests_Pause
+    - title: ReadMemory
+      anchor: Requests_ReadMemory
     - title: Restart
       anchor: Requests_Restart
     - title: RestartFrame
@@ -141,6 +145,8 @@
       anchor: Types_DataBreakpoint
     - title: DataBreakpointAccessType
       anchor: Types_DataBreakpointAccessType
+    - title: DisassembledInstruction
+      anchor: Types_DisassembledInstruction
     - title: ExceptionBreakMode
       anchor: Types_ExceptionBreakMode
     - title: ExceptionBreakpointsFilter

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ sectionid: changelog
 
 #### All notable changes to the specification will be documented in this file.
 
+* 1.35.x:
+  * Add experimental support for memory access via a new `readMemory` request and a corresponding `supportsReadMemoryRequest` capability.
+  * Add experimental support for memory disassembly via a new `disassemble` request and a corresponding `supportsDisassembleRequest` capability.
+
 * 1.34.x:
   * Added support for data breakpoints via the 'dataBreakpointInfo' and 'setDataBreakpoints' requests and the 'supportsDataBreakpoints' capability.
   * Improved some comments.

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -457,6 +457,10 @@
 										"Debugger attached to an existing process.",
 										"A project launcher component has launched a new process in a suspended state and then asked the debugger to attach."
 									]
+								},
+								"pointerSize": {
+									"type": "integer",
+									"description": "The size of a pointer or address for this process, in bits. This value may be used by clients when formatting addresses for display."
 								}
 							},
 							"required": [ "name" ]
@@ -627,6 +631,10 @@
 				"supportsRunInTerminalRequest": {
 					"type": "boolean",
 					"description": "Client supports the runInTerminal request."
+				},
+				"supportsMemoryReferences": {
+					"type": "boolean",
+					"description": "Client supports memory references."
 				}
 			},
 			"required": [ "adapterID" ]
@@ -2009,6 +2017,10 @@
 							"indexedVariables": {
 								"type": "number",
 								"description": "The number of indexed child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks."
+							},
+							"memoryReference": {
+								"type": "string",
+								"description": "Memory reference to a location appropriate for this result. For pointer type eval results, this is generally a reference to the memory address contained in the pointer."
 							}
 						},
 						"required": [ "result", "variablesReference" ]
@@ -2326,6 +2338,133 @@
 			}]
 		},
 
+		"ReadMemoryRequest": {
+			"allOf": [ { "$ref": "#/definitions/Request" }, {
+				"type": "object",
+				"description": "Reads bytes from memory at the provided location.",
+				"properties": {
+					"command": {
+						"type": "string",
+						"enum": [ "readMemory" ]
+					},
+					"arguments": {
+						"$ref": "#/definitions/ReadMemoryArguments"
+					}
+				},
+				"required": [ "command", "arguments" ]
+			}]
+		},
+		"ReadMemoryArguments": {
+			"type": "object",
+			"description": "Arguments for 'readMemory' request.",
+			"properties": {
+				"memoryReference": {
+					"type": "string",
+					"description": "Memory reference to the base location from which data should be read."
+				},
+				"offset": {
+					"type": "integer",
+					"description": "Optional offset (in bytes) to be applied to the reference location before reading data. Can be negative."
+				},
+				"count": {
+					"type": "integer",
+					"description": "Number of bytes to read at the specified location and offset."
+				}
+			},
+			"required": [ "memoryReference", "count" ]
+		},
+		"ReadMemoryResponse": {
+			"allOf": [ { "$ref": "#/definitions/Response" }, {
+				"type": "object",
+				"description": "Response to 'readMemory' request.",
+				"properties": {
+					"body": {
+						"type": "object",
+						"properties": {
+							"address": {
+								"type": "string",
+								"description": "The address of the first byte of data returned. Treated as a hex value if prefixed with '0x', or as a decimal value otherwise."
+							},
+							"unreadableBytes": {
+								"type": "integer",
+								"description": "The number of unreadable bytes encountered after the last successfully read byte. This can be used to determine the number of bytes that must be skipped before a subsequent 'readMemory' request will succeed."
+							},
+							"data": {
+								"type": "string",
+								"description": "The bytes read from memory, encoded using base64."
+							}
+						},
+						"required": [ "address" ]
+					}
+				}
+			}]
+		},
+
+		"DisassembleRequest": {
+			"allOf": [ { "$ref": "#/definitions/Request" }, {
+				"type": "object",
+				"description": "Disassembles code stored at the provided location.",
+				"properties": {
+					"command": {
+						"type": "string",
+						"enum": [ "disassemble" ]
+					},
+					"arguments": {
+						"$ref": "#/definitions/DisassembleArguments"
+					}
+				},
+				"required": [ "command", "arguments" ]
+			}]
+		},
+		"DisassembleArguments": {
+			"type": "object",
+			"description": "Arguments for 'disassemble' request.",
+			"properties": {
+				"memoryReference": {
+					"type": "string",
+					"description": "Memory reference to the base location containing the instructions to disassemble."
+				},
+				"offset": {
+					"type": "integer",
+					"description": "Optional offset (in bytes) to be applied to the reference location before disassembling. Can be negative."
+				},
+				"instructionOffset": {
+					"type": "integer",
+					"description": "Optional offset (in instructions) to be applied after the byte offset (if any) before disassembling. Can be negative."
+				},
+				"instructionCount": {
+					"type": "integer",
+					"description": "Number of instructions to disassemble starting at the specified location and offset. An adapter must return exactly this number of instructions - any unavailable instructions should be replaced with an implementation-defined 'invalid instruction' value."
+				},
+				"resolveSymbols": {
+					"type": "boolean",
+					"description": "If true, the adapter should attempt to resolve memory addresses and other values to symbolic names."
+				}
+			},
+			"required": [ "memoryReference", "instructionCount" ]
+		},
+		"DisassembleResponse": {
+			"allOf": [ { "$ref": "#/definitions/Response" }, {
+				"type": "object",
+				"description": "Response to 'disassemble' request.",
+				"properties": {
+					"body": {
+						"type": "object",
+						"properties": {
+							"instructions": {
+								"type": "array",
+								"items": {
+									"$ref": "#/definitions/DisassembledInstruction2"
+								},
+								"description": "The list of disassembled instructions."
+							}
+						},
+						"required": [ "instructions" ]
+					}
+				}
+			}]
+		},
+
 		"Capabilities": {
 			"type": "object",
 			"title": "Types",
@@ -2447,6 +2586,14 @@
 				"supportsDataBreakpoints": {
 					"type": "boolean",
 					"description": "The debug adapter supports data breakpoints."
+				},
+				"supportsReadMemoryRequest": {
+					"type": "boolean",
+					"description": "The debug adapter supports the 'readMemory' request."
+				},
+				"supportsDisassembleRequest": {
+					"type": "boolean",
+					"description": "The debug adapter supports the 'disassemble' request."
 				}
 			}
 		},
@@ -2696,6 +2843,10 @@
 					"type": "integer",
 					"description": "An optional end column of the range covered by the stack frame."
 				},
+				"instructionPointerReference": {
+					"type": "string",
+					"description": "Optional memory reference for the current instruction pointer in this frame."
+				},
 				"moduleId": {
 					"type": ["integer", "string"],
 					"description": "The module associated with this frame, if any."
@@ -2792,6 +2943,10 @@
 				"indexedVariables": {
 					"type": "integer",
 					"description": "The number of indexed child variables.\nThe client can use this optional information to present the children in a paged UI and fetch them in chunks."
+				},
+				"memoryReference": {
+					"type": "string",
+					"description": "Optional memory reference for the variable if the variable represents executable code, such as a function pointer."
 				}
 			},
 			"required": [ "name", "value", "variablesReference" ]
@@ -3005,6 +3160,10 @@
 				"endColumn": {
 					"type": "integer",
 					"description": "An optional end column of the range covered by the goto target."
+				},
+				"instructionPointerReference": {
+					"type": "string",
+					"description": "Optional memory reference for the instruction pointer value represented by this target."
 				}
 			},
 			"required": [ "id", "label", "line" ]
@@ -3190,6 +3349,50 @@
 					"description": "Details of the exception contained by this exception, if any."
 				}
 			}
+		},
+
+		"DisassembledInstruction": {
+			"type": "object",
+			"description": "Represents a single disassembled instruction.",
+			"properties": {
+				"address": {
+					"type": "string",
+					"description": "The address of the instruction. Treated as a hex value if prefixed with '0x', or as a decimal value otherwise."
+				},
+				"instructionBytes": {
+					"type": "string",
+					"description": "Optional raw bytes representing the instruction and its operands, in an implementation-defined format."
+				},
+				"instruction": {
+					"type": "string",
+					"description": "Text representing the instruction and its operands, in an implementation-defined format."
+				},
+				"symbol": {
+					"type": "string",
+					"description": "Name of the symbol that correponds with the location of this instruction, if any."
+				},
+				"location": {
+					"$ref": "#/definitions/Source",
+					"description": "Source location that corresponds to this instruction, if any. Should always be set (if available) on the first instruction returned, but can be omitted afterwards if this instruction maps to the same source file as the previous instruction."
+				},
+				"line": {
+					"type": "integer",
+					"description": "The line within the source location that corresponds to this instruction, if any."
+				},
+				"column": {
+					"type": "integer",
+					"description": "The column within the line that corresponds to this instruction, if any."
+				},
+				"endLine": {
+					"type": "integer",
+					"description": "The end line of the range that corresponds to this instruction, if any."
+				},
+				"endColumn": {
+					"type": "integer",
+					"description": "The end column of the range that corresponds to this instruction, if any."
+				}
+			},
+			"required": [ "address", "instruction" ]
 		}
 
 	}

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -2454,7 +2454,7 @@
 							"instructions": {
 								"type": "array",
 								"items": {
-									"$ref": "#/definitions/DisassembledInstruction2"
+									"$ref": "#/definitions/DisassembledInstruction"
 								},
 								"description": "The list of disassembled instructions."
 							}


### PR DESCRIPTION
Based on Andrew's PR microsoft/vscode-debugadapter-node#212 I've created a new PR for the DAP repo (where the truth lives).

I've only changed the name of the `pointerLength` attribute of the process event to `pointerSize` because the description was already talking about "size" and the Internet thinks that "pointer size" is more common than "pointer length".
