### PR TITLE
Add Papyrus implementation

### DIFF
--- a/_implementors/adapters.md
+++ b/_implementors/adapters.md
@@ -41,6 +41,7 @@ The following table lists the known debug adapters that implement the Debug Adap
 [Mono Debug](https://marketplace.visualstudio.com/items?itemName=ms-vscode.mono-debug)|[@weinand](https://github.com/weinand)|[Microsoft/vscode-mono-debug](https://github.com/Microsoft/vscode-mono-debug)
 [NativeScript](https://marketplace.visualstudio.com/items?itemName=Telerik.nativescript)|[@ivanbuhov](https://github.com/ivanbuhov)|[NativeScript/nativescript-vscode-extension](https://github.com/NativeScript/nativescript-vscode-extension/)
 [Node Debug](https://github.com/Microsoft/vscode-node-debug)|[@weinand](https://github.com/weinand)|[Microsoft/vscode-node-debug](https://github.com/Microsoft/vscode-node-debug)
+[Papyrus](https://marketplace.visualstudio.com/items?itemName=joelday.papyrus-lang-vscode)|[@joelday](https://github.com/joelday)|[joelday/papyrus-debug-server](https://github.com/joelday/papyrus-debug-server)
 [Perl Debug](https://marketplace.visualstudio.com/items?itemName=mortenhenriksen.perl-debug)|[@raix](https://github.com/raix)|[raix/vscode-perl-debug](https://github.com/raix/vscode-perl-debug)
 [Php](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug)|[@felixfbecker](https://github.com/felixfbecker)|[felixfbecker/vscode-php-debug](https://github.com/felixfbecker/vscode-php-debug)
 [PowerShell](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell)|[@daviwil](https://github.com/daviwil) [@rkeithhill](https://github.com/rkeithhill)|[PowerShell/vscode-powershell](https://github.com/PowerShell/vscode-powershell)


### PR DESCRIPTION
Provides live debugging of Papyrus scripts in Fallout 4 and Skyrim. Distributed along with the language service implementation vscode extension. Thanks!