### PR TITLE
Add an optional 'sessionId' parameter to ProtocolMessage

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -20,6 +20,10 @@
 					"type": "string",
 					"description": "Message type.",
 					"_enum": [ "request", "response", "event" ]
+				},
+				"sessionId": {
+					"type": "string",
+					"description": "Optional unique identifier indicating for which debugging session this protocol message is bound"
 				}
 			},
 			"required": [ "seq", "type" ]


### PR DESCRIPTION
A first step in enabling a "flat session" mode of communication in the protocol (see https://github.com/microsoft/debug-adapter-protocol/issues/79 for more details).