### PR TITLE
Add instruction breakpoints

### DIFF
--- a/_data/specification-toc.yml
+++ b/_data/specification-toc.yml
@@ -107,6 +107,8 @@
       anchor: Requests_SetExpression
     - title: SetFunctionBreakpoints
       anchor: Requests_SetFunctionBreakpoints
+    - title: SetInstructionBreakpoints
+      anchor: Requests_SetInstructionBreakpoints
     - title: SetVariable
       anchor: Requests_SetVariable
     - title: Source
@@ -173,6 +175,8 @@
       anchor: Types_FunctionBreakpoint
     - title: GotoTarget
       anchor: Types_GotoTarget
+    - title: InstructionBreakpoint
+      anchor: Types_InstructionBreakpoint
     - title: Message
       anchor: Types_Message
     - title: Module

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -193,7 +193,7 @@
 							"reason": {
 								"type": "string",
 								"description": "The reason for the event.\nFor backward compatibility this string is shown in the UI if the 'description' attribute is missing (but it must not be translated).",
-								"_enum": [ "step", "breakpoint", "exception", "pause", "entry", "goto", "function breakpoint", "data breakpoint" ]
+								"_enum": [ "step", "breakpoint", "exception", "pause", "entry", "goto", "function breakpoint", "data breakpoint", "instruction breakpoint" ]
 							},
 							"description": {
 								"type": "string",
@@ -1347,6 +1347,63 @@
 									"$ref": "#/definitions/Breakpoint"
 								},
 								"description": "Information about the data breakpoints. The array elements correspond to the elements of the input argument 'breakpoints' array."
+							}
+						},
+						"required": [ "breakpoints" ]
+					}
+				},
+				"required": [ "body" ]
+			}]
+		},
+
+		"SetInstructionBreakpointsRequest": {
+			"allOf": [
+				{ "$ref": "#/definitions/Request" },
+				{
+					"type": "object",
+					"description": "Replaces all existing instruction breakpoints. Typically, instruction breakpoints would be set from a diassembly window. \nTo clear all instruction breakpoints, specify an empty array.\nWhen an instruction breakpoint is hit, a 'stopped' event (with reason 'instruction breakpoint') is generated.\nClients should only call this request if the capability 'supportsInstructionBreakpoints' is true.",
+					"properties": {
+						"command": {
+						"type": "string",
+						"enum": [ "setInstructionBreakpoints" ]
+					},
+					"arguments": {
+						"$ref": "#/definitions/SetInstructionBreakpointsArguments"
+					}
+				},
+				"required": [ "command", "arguments" ]
+			}]
+		},
+		"SetInstructionBreakpointsArguments": {
+			"type": "object",
+			"description": "Arguments for 'setInstructionBreakpoints' request",
+			"properties": {
+				"breakpoints": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/InstructionBreakpoint"
+					},
+					"description": "The instruction references of the breakpoints"
+				}
+			},
+			"required": ["breakpoints"]
+		},
+		"SetInstructionBreakpointsResponse": {
+			"allOf": [
+				{ "$ref": "#/definitions/Response" },
+				{
+					"type": "object",
+					"description": "Response to 'setInstructionBreakpoints' request",
+					"properties": {
+						"body": {
+							"type": "object",
+							"properties": {
+								"breakpoints": {
+									"type": "array",
+									"items": {
+										"$ref": "#/definitions/Breakpoint"
+									},
+								"description": "Information about the breakpoints. The array elements correspond to the elements of the 'breakpoints' array."
 							}
 						},
 						"required": [ "breakpoints" ]
@@ -2840,6 +2897,10 @@
 				"supportsClipboardContext": {
 					"type": "boolean",
 					"description": "The debug adapter supports the 'clipboard' context value in the 'evaluate' request."
+				},
+				"supportsInstructionBreakpoints": {
+					"type": "boolean",
+					"description": "The debug adapter supports adding breakpoints based on instruction references."
 				}
 			}
 		},
@@ -3357,9 +3418,33 @@
 			"required": [ "dataId" ]
 		},
 
+		"InstructionBreakpoint": {
+			"type": "object",
+			"description": "Properties of a breakpoint passed to the setInstructionBreakpoints request",
+			"properties": {
+				"instructionReference": {
+					"type": "string",
+					"description": "The instruction reference of the breakpoint.\nThis should be a memory or instruction pointer reference from an EvaluateResponse, Variable, StackFrame, GotoTarget, or Breakpoint."
+				},
+				"offset": {
+					"type": "integer",
+					"description": "An optional offset from the instruction reference.\nThis can be negative."
+				},
+				"condition": {
+					"type": "string",
+					"description": "An optional expression for conditional breakpoints.\nIt is only honored by a debug adapter if the capability 'supportsConditionalBreakpoints' is true."
+				},
+				"hitCondition": {
+					"type": "string",
+					"description": "An optional expression that controls how many hits of the breakpoint are ignored.\nThe backend is expected to interpret the expression as needed.\nThe attribute is only honored by a debug adapter if the capability 'supportsHitConditionalBreakpoints' is true."
+				}
+			},
+			"required": [ "instructionReference" ]
+		},
+
 		"Breakpoint": {
 			"type": "object",
-			"description": "Information about a Breakpoint created in setBreakpoints or setFunctionBreakpoints.",
+			"description": "Information about a Breakpoint created in setBreakpoints, setFunctionBreakpoints, setInstructionBreakpoints, or setDataBreakpoints.",
 			"properties": {
 				"id": {
 					"type": "integer",
@@ -3392,6 +3477,14 @@
 				"endColumn": {
 					"type": "integer",
 					"description": "An optional end column of the actual range covered by the breakpoint.\nIf no end line is given, then the end column is assumed to be in the start line."
+				},
+				"instructionReference": {
+					"type": "string",
+					"description": "An optional memory reference to where the breakpoint is set."
+				},
+				"offset": {
+					"type": "integer",
+					"description": "An optional offset from the instruction reference.\nThis can be negative."
 				}
 			},
 			"required": [ "verified" ]

--- a/specification.md
+++ b/specification.md
@@ -223,7 +223,7 @@ interface StoppedEvent extends Event {
     /**
      * The reason for the event.
      * For backward compatibility this string is shown in the UI if the 'description' attribute is missing (but it must not be translated).
-     * Values: 'step', 'breakpoint', 'exception', 'pause', 'entry', 'goto', 'function breakpoint', 'data breakpoint', etc.
+     * Values: 'step', 'breakpoint', 'exception', 'pause', 'entry', 'goto', 'function breakpoint', 'data breakpoint', 'instruction breakpoint', etc.
      */
     reason: string;
 
@@ -1346,6 +1346,50 @@ interface SetDataBreakpointsResponse extends Response {
   body: {
     /**
      * Information about the data breakpoints. The array elements correspond to the elements of the input argument 'breakpoints' array.
+     */
+    breakpoints: Breakpoint[];
+  };
+}
+```
+
+### <a name="Requests_SetInstructionBreakpoints" class="anchor"></a>:leftwards_arrow_with_hook: SetInstructionBreakpoints Request
+
+Replaces all existing instruction breakpoints. Typically, instruction breakpoints would be set from a diassembly window. 
+
+To clear all instruction breakpoints, specify an empty array.
+
+When an instruction breakpoint is hit, a 'stopped' event (with reason 'instruction breakpoint') is generated.
+
+Clients should only call this request if the capability 'supportsInstructionBreakpoints' is true.
+
+```typescript
+interface SetInstructionBreakpointsRequest extends Request {
+  command: 'setInstructionBreakpoints';
+
+  arguments: SetInstructionBreakpointsArguments;
+}
+```
+
+Arguments for 'setInstructionBreakpoints' request
+
+<a name="Types_SetInstructionBreakpointsArguments" class="anchor"></a>
+```typescript
+interface SetInstructionBreakpointsArguments {
+  /**
+   * The instruction references of the breakpoints
+   */
+  breakpoints: InstructionBreakpoint[];
+}
+```
+
+Response to 'setInstructionBreakpoints' request
+
+<a name="Types_SetInstructionBreakpointsResponse" class="anchor"></a>
+```typescript
+interface SetInstructionBreakpointsResponse extends Response {
+  body: {
+    /**
+     * Information about the breakpoints. The array elements correspond to the elements of the 'breakpoints' array.
      */
     breakpoints: Breakpoint[];
   };
@@ -2812,6 +2856,11 @@ interface Capabilities {
    * The debug adapter supports the 'clipboard' context value in the 'evaluate' request.
    */
   supportsClipboardContext?: boolean;
+
+  /**
+   * The debug adapter supports adding breakpoints based on instruction references.
+   */
+  supportsInstructionBreakpoints?: boolean;
 }
 ```
 
@@ -3453,9 +3502,42 @@ interface DataBreakpoint {
 }
 ```
 
+### <a name="Types_InstructionBreakpoint" class="anchor"></a>InstructionBreakpoint
+
+Properties of a breakpoint passed to the setInstructionBreakpoints request
+
+```typescript
+interface InstructionBreakpoint {
+  /**
+   * The instruction reference of the breakpoint.
+   * This should be a memory or instruction pointer reference from an EvaluateResponse, Variable, StackFrame, GotoTarget, or Breakpoint.
+   */
+  instructionReference: string;
+
+  /**
+   * An optional offset from the instruction reference.
+   * This can be negative.
+   */
+  offset?: number;
+
+  /**
+   * An optional expression for conditional breakpoints.
+   * It is only honored by a debug adapter if the capability 'supportsConditionalBreakpoints' is true.
+   */
+  condition?: string;
+
+  /**
+   * An optional expression that controls how many hits of the breakpoint are ignored.
+   * The backend is expected to interpret the expression as needed.
+   * The attribute is only honored by a debug adapter if the capability 'supportsHitConditionalBreakpoints' is true.
+   */
+  hitCondition?: string;
+}
+```
+
 ### <a name="Types_Breakpoint" class="anchor"></a>Breakpoint
 
-Information about a Breakpoint created in setBreakpoints or setFunctionBreakpoints.
+Information about a Breakpoint created in setBreakpoints, setFunctionBreakpoints, setInstructionBreakpoints, or setDataBreakpoints.
 
 ```typescript
 interface Breakpoint {
@@ -3500,6 +3582,17 @@ interface Breakpoint {
    * If no end line is given, then the end column is assumed to be in the start line.
    */
   endColumn?: number;
+
+  /**
+   * An optional memory reference to where the breakpoint is set.
+   */
+  instructionReference?: string;
+
+  /**
+   * An optional offset from the instruction reference.
+   * This can be negative.
+   */
+  offset?: number;
 }
 ```
 


### PR DESCRIPTION
This adds support for instruction breakpoints (capability, request,
response, arguments) to the protocol.

This provides support for proposal https://github.com/microsoft/debug-adapter-protocol/issues/102