### PR TITLE
Add stepping granularities to the step requests.

### DIFF
--- a/_data/specification-toc.yml
+++ b/_data/specification-toc.yml
@@ -191,6 +191,8 @@
       anchor: Types_StackFrameFormat
     - title: StepInTarget
       anchor: Types_StepInTarget
+    - title: SteppingGranularity
+      anchor: Types_SteppingGranularity
     - title: Thread
       anchor: Types_Thread
     - title: ValueFormat

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -1425,6 +1425,10 @@
 				"threadId": {
 					"type": "integer",
 					"description": "Execute 'next' for this thread."
+				},
+				"granularity": {
+					"$ref": "#/definitions/SteppingGranularity",
+					"description": "Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1463,6 +1467,10 @@
 				"targetId": {
 					"type": "integer",
 					"description": "Optional id of the target to step into."
+				},
+				"granularity": {
+					"$ref": "#/definitions/SteppingGranularity",
+					"description": "Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1497,6 +1505,10 @@
 				"threadId": {
 					"type": "integer",
 					"description": "Execute 'stepOut' for this thread."
+				},
+				"granularity": {
+					"$ref": "#/definitions/SteppingGranularity",
+					"description": "Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1531,6 +1543,10 @@
 				"threadId": {
 					"type": "integer",
 					"description": "Execute 'stepBack' for this thread."
+				},
+				"granularity": {
+					"$ref": "#/definitions/SteppingGranularity",
+					"description": "Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed."
 				}
 			},
 			"required": [ "threadId" ]
@@ -2840,6 +2856,10 @@
 				"supportsClipboardContext": {
 					"type": "boolean",
 					"description": "The debug adapter supports the 'clipboard' context value in the 'evaluate' request."
+				},
+				"supportsSteppingGranularity": {
+					"type": "boolean",
+					"description": "The debug adapter supports stepping granularities."
 				}
 			}
 		},
@@ -3395,6 +3415,12 @@
 				}
 			},
 			"required": [ "verified" ]
+		},
+
+		"SteppingGranularity": {
+			"type": "string",
+			"description": "The granularity of the requested step.",
+			"enum": [ "statement", "line", "instruction" ]
 		},
 
 		"StepInTarget": {

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -3420,7 +3420,12 @@
 		"SteppingGranularity": {
 			"type": "string",
 			"description": "The granularity of the requested step.",
-			"enum": [ "statement", "line", "instruction" ]
+			"enum": [ "statement", "line", "instruction" ],
+			"enumDescriptions": [
+				"The step should allow the program to run until the current statement has finished executing.\nThe meaning of a statement is determined by the adapter and it may be considered equivalent to a line.\nFor example 'for(int i = 0; i < 10; i++) could be considered to have 3 statements 'int i = 0', 'i < 10', and 'i++'.",
+				"The step should allow the program to run until the current source line has executed.",
+				"The step should allow one instruction to execute (e.g. one x86 instruction)."
+			]
 		},
 
 		"StepInTarget": {

--- a/spec-generator/generator.ts
+++ b/spec-generator/generator.ts
@@ -128,7 +128,6 @@ function Type(typeName: string, definition: P.Definition | P.StringType, superty
 	s += '```typescript\n';
 
 	if ((<P.StringType>definition).enum) {
-		s += comment(<P.StringType> definition);
 		s += Enum(typeName, <P.StringType> definition);
 	} else {
 		s += Interface(typeName, <P.Definition> definition, supertype);

--- a/spec-generator/generator.ts
+++ b/spec-generator/generator.ts
@@ -128,6 +128,7 @@ function Type(typeName: string, definition: P.Definition | P.StringType, superty
 	s += '```typescript\n';
 
 	if ((<P.StringType>definition).enum) {
+		s += comment(<P.StringType> definition);
 		s += Enum(typeName, <P.StringType> definition);
 	} else {
 		s += Interface(typeName, <P.Definition> definition, supertype);

--- a/specification.md
+++ b/specification.md
@@ -3446,7 +3446,6 @@ interface FunctionBreakpoint {
 This enumeration defines all possible access types for data breakpoints.
 
 ```typescript
-This enumeration defines all possible access types for data breakpoints.
 type DataBreakpointAccessType = 'read' | 'write' | 'readWrite';
 ```
 
@@ -3534,12 +3533,6 @@ interface Breakpoint {
 The granularity of the requested step.
 
 ```typescript
-The granularity of the requested step.
-'statement': The step should allow the program to run until the current statement has finished executing.
-The meaning of a statement is determined by the adapter and it may be considered equivalent to a line.
-For example 'for(int i = 0; i < 10; i++) could be considered to have 3 statements 'int i = 0', 'i < 10', and 'i++'.
-'line': The step should allow the program to run until the current source line has executed.
-'instruction': The step should allow one instruction to execute (e.g. one x86 instruction).
 type SteppingGranularity = 'statement' | 'line' | 'instruction';
 ```
 
@@ -3665,7 +3658,6 @@ interface CompletionItem {
 Some predefined types for the CompletionItem. Please note that not all clients have specific icons for all of them.
 
 ```typescript
-Some predefined types for the CompletionItem. Please note that not all clients have specific icons for all of them.
 type CompletionItemType = 'method' | 'function' | 'constructor' | 'field' | 'variable' | 'class' | 'interface' | 'module' | 'property' | 'unit' | 'value' | 'enum' | 'keyword' | 'snippet' | 'text' | 'color' | 'file' | 'reference' | 'customcolor';
 ```
 
@@ -3674,7 +3666,6 @@ type CompletionItemType = 'method' | 'function' | 'constructor' | 'field' | 'var
 Names of checksum algorithms that may be supported by a debug adapter.
 
 ```typescript
-Names of checksum algorithms that may be supported by a debug adapter.
 type ChecksumAlgorithm = 'MD5' | 'SHA1' | 'SHA256' | 'timestamp';
 ```
 
@@ -3784,11 +3775,6 @@ unhandled: breaks when exception unhandled,
 userUnhandled: breaks if the exception is not handled by user code.
 
 ```typescript
-This enumeration defines all possible conditions when a thrown exception should result in a break.
-never: never breaks,
-always: always breaks,
-unhandled: breaks when exception unhandled,
-userUnhandled: breaks if the exception is not handled by user code.
 type ExceptionBreakMode = 'never' | 'always' | 'unhandled' | 'userUnhandled';
 ```
 

--- a/specification.md
+++ b/specification.md
@@ -1415,6 +1415,11 @@ interface NextArguments {
    * Execute 'next' for this thread.
    */
   threadId: number;
+
+  /**
+   * Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed.
+   */
+  granularity?: SteppingGranularity;
 }
 ```
 
@@ -1462,6 +1467,11 @@ interface StepInArguments {
    * Optional id of the target to step into.
    */
   targetId?: number;
+
+  /**
+   * Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed.
+   */
+  granularity?: SteppingGranularity;
 }
 ```
 
@@ -1496,6 +1506,11 @@ interface StepOutArguments {
    * Execute 'stepOut' for this thread.
    */
   threadId: number;
+
+  /**
+   * Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed.
+   */
+  granularity?: SteppingGranularity;
 }
 ```
 
@@ -1532,6 +1547,11 @@ interface StepBackArguments {
    * Execute 'stepBack' for this thread.
    */
   threadId: number;
+
+  /**
+   * Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed.
+   */
+  granularity?: SteppingGranularity;
 }
 ```
 
@@ -2812,6 +2832,11 @@ interface Capabilities {
    * The debug adapter supports the 'clipboard' context value in the 'evaluate' request.
    */
   supportsClipboardContext?: boolean;
+
+  /**
+   * The debug adapter supports stepping granularities.
+   */
+  supportsSteppingGranularity?: boolean;
 }
 ```
 
@@ -3501,6 +3526,14 @@ interface Breakpoint {
    */
   endColumn?: number;
 }
+```
+
+### <a name="Types_SteppingGranularity" class="anchor"></a>SteppingGranularity
+
+The granularity of the requested step.
+
+```typescript
+type SteppingGranularity = 'statement' | 'line' | 'instruction';
 ```
 
 ### <a name="Types_StepInTarget" class="anchor"></a>StepInTarget

--- a/specification.md
+++ b/specification.md
@@ -3446,6 +3446,7 @@ interface FunctionBreakpoint {
 This enumeration defines all possible access types for data breakpoints.
 
 ```typescript
+This enumeration defines all possible access types for data breakpoints.
 type DataBreakpointAccessType = 'read' | 'write' | 'readWrite';
 ```
 
@@ -3533,6 +3534,12 @@ interface Breakpoint {
 The granularity of the requested step.
 
 ```typescript
+The granularity of the requested step.
+'statement': The step should allow the program to run until the current statement has finished executing.
+The meaning of a statement is determined by the adapter and it may be considered equivalent to a line.
+For example 'for(int i = 0; i < 10; i++) could be considered to have 3 statements 'int i = 0', 'i < 10', and 'i++'.
+'line': The step should allow the program to run until the current source line has executed.
+'instruction': The step should allow one instruction to execute (e.g. one x86 instruction).
 type SteppingGranularity = 'statement' | 'line' | 'instruction';
 ```
 
@@ -3658,6 +3665,7 @@ interface CompletionItem {
 Some predefined types for the CompletionItem. Please note that not all clients have specific icons for all of them.
 
 ```typescript
+Some predefined types for the CompletionItem. Please note that not all clients have specific icons for all of them.
 type CompletionItemType = 'method' | 'function' | 'constructor' | 'field' | 'variable' | 'class' | 'interface' | 'module' | 'property' | 'unit' | 'value' | 'enum' | 'keyword' | 'snippet' | 'text' | 'color' | 'file' | 'reference' | 'customcolor';
 ```
 
@@ -3666,6 +3674,7 @@ type CompletionItemType = 'method' | 'function' | 'constructor' | 'field' | 'var
 Names of checksum algorithms that may be supported by a debug adapter.
 
 ```typescript
+Names of checksum algorithms that may be supported by a debug adapter.
 type ChecksumAlgorithm = 'MD5' | 'SHA1' | 'SHA256' | 'timestamp';
 ```
 
@@ -3775,6 +3784,11 @@ unhandled: breaks when exception unhandled,
 userUnhandled: breaks if the exception is not handled by user code.
 
 ```typescript
+This enumeration defines all possible conditions when a thrown exception should result in a break.
+never: never breaks,
+always: always breaks,
+unhandled: breaks when exception unhandled,
+userUnhandled: breaks if the exception is not handled by user code.
 type ExceptionBreakMode = 'never' | 'always' | 'unhandled' | 'userUnhandled';
 ```
 


### PR DESCRIPTION
This allows step requests (Next, StepInto, StepOut, StepBack) to take
an optional 'steppingGranularity', which provides a hint for how far
a debug adapter should let the step go.

This provides support for proposal https://github.com/microsoft/debug-adapter-protocol/issues/110