### PR TITLE
Add Kotlin Debug Adapter

### DIFF
--- a/_implementors/adapters.md
+++ b/_implementors/adapters.md
@@ -39,6 +39,7 @@ The following table lists the known debug adapters that implement the Debug Adap
 [JavaScript with Time-Traveling and Persistent State](https://marketplace.visualstudio.com/items?itemName=effectful.debugger)|[@awto](https://github.com/awto)|[@effectful/debugger](https://github.com/awto/effectfuljs/tree/master/packages/vscode-debugger)
 [JSIRDebugger](https://marketplace.visualstudio.com/items?itemName=muji.jsirdebugger)|muji
 [Karate](https://marketplace.visualstudio.com/items?itemName=kirkslota.karate-runner)|[@kirk_slota](https://twitter.com/kirk_slota) [@ptrthomas](https://twitter.com/ptrthomas)|[karate/karate-core](https://github.com/intuit/karate/tree/develop/karate-core/src/main/java/com/intuit/karate/debug)
+[Kotlin](https://marketplace.visualstudio.com/items?itemName=fwcd.kotlin)|[@fwcd](https://github.com/fwcd)|[fwcd/kotlin-debug-adapter](https://github.com/fwcd/kotlin-debug-adapter)
 [LLDB Debugger](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)|[@vadimcn](https://github.com/vadimcn)|[vadimcn/vscode-lldb](https://github.com/vadimcn/vscode-lldb)
 [Lua and Ravi 5.3 Debugger](https://marketplace.visualstudio.com/items?itemName=ravilang.ravi-debug)|[@dibyendumajumdar](https://github.com/dibyendumajumdar)|[dibyendumajumdar/ravi-vscode-debugger](https://github.com/dibyendumajumdar/ravi-vscode-debugger)
 [Mock Debug](https://marketplace.visualstudio.com/items?itemName=andreweinand.mock-debug)|[@weinand](https://github.com/weinand)|[Microsoft/vscode-mock-debug](https://github.com/Microsoft/vscode-mock-debug)


### PR DESCRIPTION
Add a debug adapter for Kotlin to the list of DAP implementors.