### PR TITLE
Bug #122: requestId for ProgressStartEvent is an integer

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -567,7 +567,7 @@
 								"description": "Mandatory (short) title of the progress reporting. Shown in the UI to describe the long running operation."
 							},
 							"requestId": {
-								"type": "number",
+								"type": "integer",
 								"description": "The request ID that this progress report is related to. If specified a debug adapter is expected to emit\nprogress events for the long running request until the request has been either completed or cancelled.\nIf the request ID is omitted, the progress report is assumed to be related to some general activity of the debug adapter."
 							},
 							"cancellable": {


### PR DESCRIPTION
Here is the trivial part of the fix for #122 - but I couldn't get the generated files to rebuild, so I haven't included manually edited versions.