### PR TITLE
Add hasDataBreakpoint attribute for VariablePresentationHint

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -3361,7 +3361,7 @@
 						"Indicates that the object is an interface.",
 						"Indicates that the object is the most derived class.",
 						"Indicates that the object is virtual, that means it is a synthetic object introducedby the\nadapter for rendering purposes, e.g. an index range for large arrays.",
-						"Deprecated: Indicates that a data breakpoint is registered for the object."
+						"Deprecated: Indicates that a data breakpoint is registered for the object. The 'hasDataBreakpoint' attribute should generally be used instead."
 					]
 				},
 				"attributes": {

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -3361,7 +3361,7 @@
 						"Indicates that the object is an interface.",
 						"Indicates that the object is the most derived class.",
 						"Indicates that the object is virtual, that means it is a synthetic object introducedby the\nadapter for rendering purposes, e.g. an index range for large arrays.",
-						"Indicates that a data breakpoint is registered for the object."
+						"Deprecated: Indicates that a data breakpoint is registered for the object."
 					]
 				},
 				"attributes": {
@@ -3369,7 +3369,7 @@
 					"type": "array",
 					"items": {
 						"type": "string",
-						"_enum": [ "static", "constant", "readOnly", "rawString", "hasObjectId", "canHaveObjectId", "hasSideEffects" ],
+						"_enum": [ "static", "constant", "readOnly", "rawString", "hasObjectId", "canHaveObjectId", "hasSideEffects", "hasDataBreakpoint" ],
 						"enumDescriptions": [
 							"Indicates that the object is static.",
 							"Indicates that the object is a constant.",
@@ -3377,7 +3377,8 @@
 							"Indicates that the object is a raw string.",
 							"Indicates that the object can have an Object ID created for it.",
 							"Indicates that the object has an Object ID associated with it.",
-							"Indicates that the evaluation had side effects."
+							"Indicates that the evaluation had side effects.",
+							"Indicates that the object has its value tracked by a data breakpoint."
 						]
 					}
 				},

--- a/specification.md
+++ b/specification.md
@@ -3655,8 +3655,8 @@ interface VariablePresentationHint {
    * 'virtual': Indicates that the object is virtual, that means it is a
    * synthetic object introducedby the
    * adapter for rendering purposes, e.g. an index range for large arrays.
-   * 'dataBreakpoint': Indicates that a data breakpoint is registered for the
-   * object.
+   * 'dataBreakpoint': Deprecated: Indicates that a data breakpoint is
+   * registered for the object.
    * etc.
    */
   kind?: 'property' | 'method' | 'class' | 'data' | 'event' | 'baseClass'
@@ -3676,10 +3676,12 @@ interface VariablePresentationHint {
    * 'canHaveObjectId': Indicates that the object has an Object ID associated
    * with it.
    * 'hasSideEffects': Indicates that the evaluation had side effects.
+   * 'hasDataBreakpoint': Indicates that the object has its value tracked by a
+   * data breakpoint.
    * etc.
    */
   attributes?: ('static' | 'constant' | 'readOnly' | 'rawString' | 'hasObjectId'
-      | 'canHaveObjectId' | 'hasSideEffects' | string)[];
+      | 'canHaveObjectId' | 'hasSideEffects' | 'hasDataBreakpoint' | string)[];
 
   /**
    * Visibility of variable. Before introducing additional values, try to use

--- a/specification.md
+++ b/specification.md
@@ -3656,7 +3656,8 @@ interface VariablePresentationHint {
    * synthetic object introducedby the
    * adapter for rendering purposes, e.g. an index range for large arrays.
    * 'dataBreakpoint': Deprecated: Indicates that a data breakpoint is
-   * registered for the object.
+   * registered for the object. The 'hasDataBreakpoint' attribute should
+   * generally be used instead.
    * etc.
    */
   kind?: 'property' | 'method' | 'class' | 'data' | 'event' | 'baseClass'


### PR DESCRIPTION
This adds an 'hasDataBreakpoint' attribute and deprecate 'dataBreakpoint' kind at VariablePresentationHint, per #173.