### PR TITLE
Fix a small mistake in `ExceptionFilterOptions`

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -3940,7 +3940,7 @@
 
 		"ExceptionFilterOptions": {
 			"type": "object",
-			"description": "An ExceptionFilterOptions is used to specify an exception filter together with a condition for the setExceptionsFilter request.",
+			"description": "An ExceptionFilterOptions is used to specify an exception filter together with a condition for the 'setExceptionBreakpoints' request.",
 			"properties": {
 				"filterId": {
 					"type": "string",


### PR DESCRIPTION
The description of `ExceptionFilterOptions` currently states that it is used in the `setExceptionsFilter`, which does not exist in the specification. 
It is however used in the `setExceptionBreakpoints` request so I assume this is just a wording error, hence the PR.