### PR TITLE
Add padding to some outline elements

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -435,7 +435,7 @@ pre[class=highlight] {
 	}
 }
 
-.dap-sidebar #outlineAccordion-side {
+.dap-sidebar .card {
 	padding-top: 1px;
 }
 

--- a/css/main.scss
+++ b/css/main.scss
@@ -435,6 +435,10 @@ pre[class=highlight] {
 	}
 }
 
+.dap-sidebar #outlineAccordion-side {
+	padding-top: 1px;
+}
+
 .navbar-brand h1 {
     font-size: 18px;
     font-weight: bold;
@@ -451,6 +455,11 @@ pre[class=highlight] {
 
 a {
 	color: #2753e3;
+}
+
+a h3 {
+	padding-top: 2px;
+	padding-bottom: 2px;
 }
 
 a:hover {


### PR DESCRIPTION
Ref https://github.com/microsoft/debug-adapter-protocol/issues/252

This PR fixes the following trouble spots:

Irregular outline shape around header links on the main page:
![Screenshot](https://user-images.githubusercontent.com/7199958/156852353-9ba390f6-48df-4fc1-bce3-39aba90531ab.PNG)

Clipped outline around first item of the right nav bar on the Specification page:
![Screenshot](https://user-images.githubusercontent.com/7199958/156852354-4a2363a7-a7a9-418d-87bb-9cbd9a2cc160.PNG)
