### PR TITLE
Fix description for SetBreakpointsArguments

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -1195,7 +1195,7 @@
 			"properties": {
 				"source": {
 					"$ref": "#/definitions/Source",
-					"description": "The source location of the breakpoints; either 'source.path' or 'source.reference' must be specified."
+					"description": "The source location of the breakpoints; either 'source.path' or 'source.sourceReference' must be specified."
 				},
 				"breakpoints": {
 					"type": "array",


### PR DESCRIPTION
SetBreakpointsArguments says that either source.path or source.reference must be specified.

However, source does not contain a field named reference .  I think this should say source.sourceReference instead.

(I've checked by making a debug adapter for VS Code, and both "sourceReference" and "path" are used, but not "reference")