### PR TITLE
Update adapters.md for Go debug adapter

### DIFF
--- a/_implementors/adapters.md
+++ b/_implementors/adapters.md
@@ -39,7 +39,7 @@ Many adapters publish releases tailored for specific editors, such as VS Code, a
 [ESP32 Debugger](https://github.com/espressif/esp-debug-adapter)|[@espressif](https://github.com/espressif)|[DAP Server](https://github.com/espressif/esp-debug-adapter#usage)
 [Firefox Remote Debug](https://github.com/yurydelendik/vscode-ff-debug)|[@yurydelendik](https://github.com/yurydelendik)|[VS Code](https://marketplace.visualstudio.com/items?itemName=yurydelendik.firefox-debug)
 [Flash](https://github.com/vshaxe/flash-debugger)|[@vshaxe](https://github.com/vshaxe/)|[VS Code](https://marketplace.visualstudio.com/items?itemName=vshaxe.haxe-debug)
-[Go](https://github.com/golang/vscode-go)|[@golang/tools-team](https://github.com/orgs/golang/teams/tools-team)|[VS Code](https://marketplace.visualstudio.com/items?itemName=golang.Go)
+[Go Delve Debugger](https://github.com/go-delve/delve/tree/master/service/dap)| [@polinasok](https://github.com/polinasok) and [Delve](https://github.com/go-delve)| [DAP Server](https://github.com/go-delve/delve/tree/master/Documentation/api/dap)<br>[VS Code](https://github.com/golang/vscode-go/blob/master/docs/debugging.md)
 [Harbour](https://github.com/APerricone/harbourCodeExtension)|[@APerricone](https://github.com/APerricone)|[VS Code](https://marketplace.visualstudio.com/items?itemName=aperricone.harbour)
 [HashLink](https://github.com/vshaxe/hashlink-debugger)|[@vshaxe](https://github.com/vshaxe/)|[VS Code](https://marketplace.visualstudio.com/items?itemName=HaxeFoundation.haxe-hl)
 [Haskell GHCi debug viewer Phoityne](https://github.com/phoityne/phoityne-vscode)|[@phoityne](https://github.com/phoityne)|[VS Code](https://marketplace.visualstudio.com/items?itemName=phoityne.phoityne-vscode)

--- a/_implementors/adapters.md
+++ b/_implementors/adapters.md
@@ -39,7 +39,8 @@ Many adapters publish releases tailored for specific editors, such as VS Code, a
 [ESP32 Debugger](https://github.com/espressif/esp-debug-adapter)|[@espressif](https://github.com/espressif)|[DAP Server](https://github.com/espressif/esp-debug-adapter#usage)
 [Firefox Remote Debug](https://github.com/yurydelendik/vscode-ff-debug)|[@yurydelendik](https://github.com/yurydelendik)|[VS Code](https://marketplace.visualstudio.com/items?itemName=yurydelendik.firefox-debug)
 [Flash](https://github.com/vshaxe/flash-debugger)|[@vshaxe](https://github.com/vshaxe/)|[VS Code](https://marketplace.visualstudio.com/items?itemName=vshaxe.haxe-debug)
-[Go Delve Debugger](https://github.com/go-delve/delve/tree/master/service/dap)| [@polinasok](https://github.com/polinasok) and [Delve](https://github.com/go-delve)| [DAP Server](https://github.com/go-delve/delve/tree/master/Documentation/api/dap)<br>[VS Code](https://github.com/golang/vscode-go/blob/master/docs/debugging.md)
+[Go Delve Debugger](https://github.com/go-delve/delve/tree/master/service/dap)| [@polinasok](https://github.com/polinasok) and [Delve](https://github.com/go-delve)| [DAP Server](https://github.com/go-delve/delve/tree/master/Documentation/api/dap), [VS Code](https://github.com/golang/vscode-go/blob/master/docs/debugging.md)
+
 [Harbour](https://github.com/APerricone/harbourCodeExtension)|[@APerricone](https://github.com/APerricone)|[VS Code](https://marketplace.visualstudio.com/items?itemName=aperricone.harbour)
 [HashLink](https://github.com/vshaxe/hashlink-debugger)|[@vshaxe](https://github.com/vshaxe/)|[VS Code](https://marketplace.visualstudio.com/items?itemName=HaxeFoundation.haxe-hl)
 [Haskell GHCi debug viewer Phoityne](https://github.com/phoityne/phoityne-vscode)|[@phoityne](https://github.com/phoityne)|[VS Code](https://marketplace.visualstudio.com/items?itemName=phoityne.phoityne-vscode)


### PR DESCRIPTION
[Delve DAP Server](https://github.com/go-delve/delve/tree/master/Documentation/api/dap) is now the official DA for Go.
[VSCode Go extension](https://github.com/golang/vscode-go) no longer maintains its l[egacy DA](https://github.com/golang/vscode-go/tree/master/src/debugAdapter) and offers debugging via [Delve DAP](https://github.com/go-delve/delve/tree/master/Documentation/api/dap).

cc @hyangah @suzmue