### PR TITLE
Adding new capabilities that will be supported by vscode-js-debug

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -1937,6 +1937,10 @@
 				"format": {
 					"$ref": "#/definitions/StackFrameFormat",
 					"description": "Specifies details on how to format the stack frames.\nThe attribute is only honored by a debug adapter if the capability 'supportsValueFormattingOptions' is true."
+				},
+				"noFuncEval": {
+					"type": "boolean",
+					"description": "Exclude funceval during evaluation."
 				}
 			},
 			"required": [ "threadId" ]
@@ -2058,6 +2062,10 @@
 				"format": {
 					"$ref": "#/definitions/ValueFormat",
 					"description": "Specifies details on how to format the Variable values.\nThe attribute is only honored by a debug adapter if the capability 'supportsValueFormattingOptions' is true."
+				},
+				"evaluationOptions": {
+					"$ref": "#/definitions/EvaluationOptions",
+					"description": "Options to control how the evaluation occurs."
 				}
 			},
 			"required": [ "variablesReference" ]
@@ -2430,6 +2438,10 @@
 				"format": {
 					"$ref": "#/definitions/ValueFormat",
 					"description": "Specifies details on how to format the result.\nThe attribute is only honored by a debug adapter if the capability 'supportsValueFormattingOptions' is true."
+				},
+				"evaluationOptions": {
+					"$ref": "#/definitions/EvaluationOptions",
+					"description": "Options to control how the evaluation occurs."
 				}
 			},
 			"required": [ "expression" ]
@@ -3146,6 +3158,14 @@
 				"supportsSingleThreadExecutionRequests": {
 					"type": "boolean",
 					"description": "The debug adapter supports the 'singleThread' property on the execution requests ('continue', 'next', 'stepIn', 'stepOut', 'reverseContinue', 'stepBack')."
+				},
+				"supportsDebuggerProperties": {
+					"type": "boolean",
+					"description": "The debug adapter supports the 'setDebuggerProperty' request."
+				},
+				"supportsEvaluationOptions": {
+					"type": "boolean",
+					"description": "The debug adapter supports EvaluationOptions on evaluation and variables requests."
 				}
 			}
 		},
@@ -4087,6 +4107,80 @@
 				"Previously fetched thread related data has become invalid and needs to be refetched.",
 				"Previously fetched variable data has become invalid and needs to be refetched."
 			]
+		},
+
+		"SetDebuggerPropertyRequest": {
+			"allOf": [ { "$ref": "#/definitions/Request" },
+			{
+				"type": "object",
+				"description": "Sets a debugger property.",
+				"properties": {
+				"command": {
+					"type": "string",
+					"enum": [ "setDebuggerProperty" ]
+				},
+				"arguments": {
+					"$ref": "#/definitions/SetDebuggerPropertyArguments"
+				}
+				},
+				"required": [ "command", "arguments" ]
+			}
+			]
+		},
+
+		"SetDebuggerPropertyArguments": {
+			"type": "object",
+			"description": "Arguments for 'setDebuggerProperty' request. Properties are determined by debugger."
+		},
+
+		"EvaluationOptions": {
+			"type": "object",
+			"description": "Options passed to expression evaluation commands ('evaluate' and 'variables') to control how the evaluation occurs.",
+			"properties": {
+			"treatAsStatement": {
+				"type": "boolean",
+				"description": "Evaluate the expression as a statement."
+			},
+			"allowImplicitVars": {
+				"type": "boolean",
+				"description": "Allow variables to be declared as part of the expression."
+			},
+			"noSideEffects": {
+				"type": "boolean",
+				"description": "Evaluate without side effects."
+			},
+			"noFuncEval": {
+				"type": "boolean",
+				"description": "Exclude funceval during evaluation."
+			},
+			"noToString": {
+				"type": "boolean",
+				"description": "Exclude calling `ToString` during evaluation."
+			},
+			"forceEvaluationNow": {
+				"type": "boolean",
+				"description": "Evaluation should take place immediately if possible."
+			},
+			"forceRealFuncEval": {
+				"type": "boolean",
+				"description": "Exclude interpretation from evaluation methods."
+			},
+			"runAllThreads": {
+				"type": "boolean",
+				"description": "Allow all threads to run during the evaluation."
+			},
+			"rawStructures": {
+				"type": "boolean",
+				"description": "The 'raw' view of objects and structions should be shown - visualization improvements should be disabled."
+			},
+			"filterToFavorites": {
+				"type": "boolean",
+				"description": "Variables responses containing favorites should be filtered to only those items"
+			},
+			"simpleDisplayString": {
+				"type": "boolean",
+				"description": "Auto generated display strings for variables with favorites should not include field names."
+			}
 		}
 
 	}


### PR DESCRIPTION
Adding things needed for a better debugging experience on wasm.

We will be able to close some issues opened by users, asking for these functionalities:
- Enable and disable JMC.
- Auto evaluate properties values.

Once this is approved we can make a PR on vscode-js-debug about it.
The first one is already opened, but we can remove a lot of wokarounds if this PR is merged.
https://github.com/microsoft/vscode-js-debug/pull/1311