### PR TITLE
specify format of hash and timestamp values

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -3260,7 +3260,7 @@
 				},
 				"dateTimeStamp": {
 					"type": "string",
-					"description": "Module created or modified."
+					"description": "Module created or modified, encoded as a RFC 3339 timestamp."
 				},
 				"addressRange": {
 					"type": "string",
@@ -3885,7 +3885,7 @@
 				},
 				"checksum": {
 					"type": "string",
-					"description": "Value of the checksum."
+					"description": "Value of the checksum, encoded as a hexadecimal value."
 				}
 			},
 			"required": [ "algorithm", "checksum" ]


### PR DESCRIPTION
Closes https://github.com/microsoft/debug-adapter-protocol/issues/291

Specifies hash values as hexadecimal values, which should be unsurprising.

Specifies the timestamp as an [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339). RFC 3339 is the most common profile of ISO 8601, which addresses some shortcomings of the specification (e.g. removing support for two-digit years). Most ISO dates seen in the wild, including those from JavaScript's `new Date().toISOString()`, are RFC 3339 dates.