### PR TITLE
make wording on source.origin more clear to be non-exhaustive

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -3352,7 +3352,7 @@
 				},
 				"origin": {
 					"type": "string",
-					"description": "The (optional) origin of this source: possible values 'internal module', 'inlined content from source map', etc."
+					"description": "The optional origin of this source. For example, 'internal module', 'inlined content from source map', etc."
 				},
 				"sources": {
 					"type": "array",


### PR DESCRIPTION
Closes https://github.com/microsoft/debug-adapter-protocol/issues/288