### PR TITLE
fix generation kludge in module.path field

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -3236,7 +3236,7 @@
 				},
 				"path": {
 					"type": "string",
-					"description": "optional but recommended attributes.\nalways try to use these first before introducing additional attributes.\n\nLogical full path to the module. The exact definition is implementation defined, but usually this would be a full path to the on-disk file for the module."
+					"description": "Logical full path to the module. The exact definition is implementation defined, but usually this would be a full path to the on-disk file for the module."
 				},
 				"isOptimized": {
 					"type": "boolean",


### PR DESCRIPTION
Closes https://github.com/microsoft/debug-adapter-protocol/issues/287

Seems like a copy-paste or generation error. The docs for `module` already convey this meaning, so just remove it.