### PR TITLE
Move EvaluateArguments context variables to end of enums

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -2490,13 +2490,13 @@
 				},
 				"context": {
 					"type": "string",
-					"_enum": [ "variables", "watch", "repl", "hover", "clipboard" ],
+					"_enum": [ "watch", "repl", "hover", "clipboard", "variables" ],
 					"enumDescriptions": [
-						"evaluate is called from a variables view context.",
 						"evaluate is called from a watch view context.",
 						"evaluate is called from a REPL context.",
 						"evaluate is called to generate the debug hover contents.\nThis value should only be used if the corresponding capability `supportsEvaluateForHovers` is true.",
-						"evaluate is called to generate clipboard contents.\nThis value should only be used if the corresponding capability `supportsClipboardContext` is true."
+						"evaluate is called to generate clipboard contents.\nThis value should only be used if the corresponding capability `supportsClipboardContext` is true.",
+						"evaluate is called from a variables view context."
 					],
 					"description": "The context in which the evaluate request is used."
 				},

--- a/specification.md
+++ b/specification.md
@@ -2600,7 +2600,6 @@ interface EvaluateArguments {
   /**
    * The context in which the evaluate request is used.
    * Values: 
-   * 'variables': evaluate is called from a variables view context.
    * 'watch': evaluate is called from a watch view context.
    * 'repl': evaluate is called from a REPL context.
    * 'hover': evaluate is called to generate the debug hover contents.
@@ -2609,9 +2608,10 @@ interface EvaluateArguments {
    * 'clipboard': evaluate is called to generate clipboard contents.
    * This value should only be used if the corresponding capability
    * `supportsClipboardContext` is true.
+   * 'variables': evaluate is called from a variables view context.
    * etc.
    */
-  context?: 'variables' | 'watch' | 'repl' | 'hover' | 'clipboard' | string;
+  context?: 'watch' | 'repl' | 'hover' | 'clipboard' | 'variables' | string;
 
   /**
    * Specifies details on how to format the result.


### PR DESCRIPTION
This PR moves the newly added 'variables' enum for EvaluateArguments context from https://github.com/microsoft/debug-adapter-protocol/commit/87fdf654be233b5c7b0f32aa9a7310c6565e48af to be added at the end instead of at the start of the array.

Reordering the parameters is breaking change for downstream generators.

cc @andrewcrawley 