### PR TITLE
Update sdks.md - include dap-rs

### DIFF
--- a/_implementors/sdks.md
+++ b/_implementors/sdks.md
@@ -18,6 +18,7 @@ The following table lists the known SDKs or libraries that support the Debug Ada
 | C++ library for implementing debug adapters | C++ | Google | [google/cppdap](https://github.com/google/cppdap)
 | Ruby library for encoding and decoding DAP messages | Ruby | [Ethan Reesor](https://gitlab.com/firelizzard) | [firelizzard/ruby-dap](https://gitlab.com/firelizzard/ruby-dap)
 | Go library for DAP | Go | Go team at Google | [google/go-dap](https://github.com/google/go-dap)
+| A Rust implementation of the Debug Adapter Protocol | Rust | [Tamás Szelei](https://github.com/sztomi) | [sztomi/dap-rs](https://github.com/sztomi/dap-rs)
 {: .table .table-bordered .table-responsive}
 
 *If you are missing a SDK please create a pull request in GitHub against this markdown [document](https://github.com/Microsoft/debug-adapter-protocol/blob/gh-pages/_implementors/sdks.md)*


### PR DESCRIPTION
I've created a Rust implementation for DAP and released an alpha version on crates.io. It's in a fairly early state (but it's code-complete). 