### PR TITLE
clarify the default behavior when kind is omitted from runInTerminal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ sectionid: changelog
 
 * 1.59.x:
   * Clarify the lifetime of `variablesReference`.
+  * Clarify the default behavior when `kind` is omitted from the `RunInTerminalRequest`.
 
 * 1.58.x:
   * Specify the measurement unit of various `column` and "character positions" properties to be "UTF-16 code units".

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -755,7 +755,7 @@
 				"kind": {
 					"type": "string",
 					"enum": [ "integrated", "external" ],
-					"description": "What kind of terminal to launch."
+					"description": "What kind of terminal to launch. Defaults to `integrated` if not specified."
 				},
 				"title": {
 					"type": "string",


### PR DESCRIPTION
Fixes #43