### PR TITLE
Clarify that absent canRestart on frame implies true

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -3486,7 +3486,7 @@
 				},
 				"canRestart": {
 					"type": "boolean",
-					"description": "Indicates whether this frame can be restarted with the `restart` request. Clients should only use this if the debug adapter supports the `restart` request and the corresponding capability `supportsRestartRequest` is true."
+					"description": "Indicates whether this frame can be restarted with the `restart` request. Clients should only use this if the debug adapter supports the `restart` request and the corresponding capability `supportsRestartRequest` is true. If a debug adapter has this capability, then `canRestart` defaults to `true` if the property is absent."
 				},
 				"instructionPointerReference": {
 					"type": "string",

--- a/specification.md
+++ b/specification.md
@@ -3797,6 +3797,8 @@ interface StackFrame {
    * Indicates whether this frame can be restarted with the `restart` request.
    * Clients should only use this if the debug adapter supports the `restart`
    * request and the corresponding capability `supportsRestartRequest` is true.
+   * If a debug adapter has this capability, then `canRestart` defaults to
+   * `true` if the property is absent.
    */
   canRestart?: boolean;
 


### PR DESCRIPTION
Closes https://github.com/microsoft/debug-adapter-protocol/issues/347
