### PR TITLE
Add support for Checkpoint requests

### DIFF
--- a/_data/specification-toc.yml
+++ b/_data/specification-toc.yml
@@ -59,14 +59,20 @@
       anchor: Requests_Attach
     - title: BreakpointLocations
       anchor: Requests_BreakpointLocations
+    - title: CheckpointArguments
+      anchor: Requests_CheckpointArguments
     - title: Completions
       anchor: Requests_Completions
     - title: ConfigurationDone
       anchor: Requests_ConfigurationDone
     - title: Continue
       anchor: Requests_Continue
+    - title: CreateCheckpoint
+      anchor: Requests_CreateCheckpoint
     - title: DataBreakpointInfo
       anchor: Requests_DataBreakpointInfo
+    - title: DeleteCheckpoint
+      anchor: Requests_DeleteCheckpoint
     - title: Disassemble
       anchor: Requests_Disassemble
     - title: Disconnect
@@ -83,6 +89,8 @@
       anchor: Requests_Initialize
     - title: Launch
       anchor: Requests_Launch
+    - title: LoadCheckpoint
+      anchor: Requests_LoadCheckpoint
     - title: LoadedSources
       anchor: Requests_LoadedSources
     - title: Modules

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ sectionid: changelog
 
 #### All notable changes to the specification will be documented in this file.
 
+* 1.61.x
+  * Add `supportsCheckpointRequests` capability (`createCheckpoint`, `deleteCheckpoint` and 
+  `loadCheckpoint`).
+
 * 1.60.x
   * Clarify the usage of `hitCondition` and `logMessage` in `SetBreakpointsRequest`
 

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -3051,6 +3051,117 @@
 			}]
 		},
 
+		"CreateCheckpointRequest": {
+			"allOf": [ { "$ref": "#/definitions/Request" }, {
+				"type": "object",
+				"description": "Creates an identical copy of the process.\nClients should only call this request if the corresponding capability `supportsCheckpointRequests` is true.",
+				"properties": {
+					"command": {
+						"type": "string",
+						"enum": [ "createCheckpoint" ]
+					}
+				},
+				"required": [ "command" ]
+			}]
+		},
+		"CreateCheckpointResponse": {
+			"allOf": [ { "$ref": "#/definitions/Response" }, {
+				"type": "object",
+				"description": "Response to `createCheckpoint` request.",
+				"properties": {
+					"body": {
+						"type": "object",
+						"properties": {
+							"checkpointId": {
+								"type": "integer",
+								"description": "The newly created checkpoint ID."
+							}
+						},
+						"required": [ "checkpointId" ]
+					}
+				}
+			}]
+		},
+		"DeleteCheckpointRequest": {
+			"allOf": [ { "$ref": "#/definitions/Request" }, {
+				"type": "object",
+				"description": "Deletes the checkpoint with the ID provided.\nClients should only call this request if the corresponding capability `supportsCheckpointRequests` is true.",
+				"properties": {
+					"command": {
+						"type": "string",
+						"enum": [ "deleteCheckpoint" ]
+					},
+					"arguments": {
+						"$ref": "#/definitions/CheckpointArguments"
+					}
+				},
+				"required": [ "command", "arguments" ]
+			}]
+		},
+		"DeleteCheckpointResponse": {
+			"allOf": [ { "$ref": "#/definitions/Response" }, {
+				"type": "object",
+				"description": "Response to `deleteCheckpoint` request.",
+				"properties": {
+					"body": {
+						"type": "object",
+						"properties": {
+							"success": {
+								"type": "boolean",
+								"description": "True if the ID of the checkpoint requested for deletion existed and was successfully deleted, False otherwise."
+							}
+						},
+						"required": [ "success" ]
+					}
+				}
+			}]
+		},
+		"LoadCheckpointRequest": {
+			"allOf": [ { "$ref": "#/definitions/Request" }, {
+				"type": "object",
+				"description": "Loads the checkpoint with the ID provided.\nClients should only call this request if the corresponding capability `supportsCheckpointRequests` is true.",
+				"properties": {
+					"command": {
+						"type": "string",
+						"enum": [ "loadCheckpoint" ]
+					},
+					"arguments": {
+						"$ref": "#/definitions/CheckpointArguments"
+					}
+				},
+				"required": [ "command", "arguments" ]
+			}]
+		},
+		"LoadCheckpointResponse": {
+			"allOf": [ { "$ref": "#/definitions/Response" }, {
+				"type": "object",
+				"description": "Response to `loadCheckpoint` request.",
+				"properties": {
+					"body": {
+						"type": "object",
+						"properties": {
+							"success": {
+								"type": "boolean",
+								"description": "True if the ID of the checkpoint requested for deletion existed and was successfully loaded, False otherwise."
+							}
+						},
+						"required": [ "success" ]
+					}
+				}
+			}]
+		},
+		"CheckpointArguments": {
+			"type": "object",
+			"description": "Arguments for `deleteCheckpoint` and `loadCheckpoint` requests.",
+			"properties": {
+				"checkpointId": {
+					"type": "integer",
+					"description": "ID of the checkpoint refered to by the request."
+				}
+			},
+			"required": [ "checkpointId" ]
+		},
+
 		"Capabilities": {
 			"type": "object",
 			"title": "Types",
@@ -3223,6 +3334,10 @@
 				"supportsSingleThreadExecutionRequests": {
 					"type": "boolean",
 					"description": "The debug adapter supports the `singleThread` property on the execution requests (`continue`, `next`, `stepIn`, `stepOut`, `reverseContinue`, `stepBack`)."
+				},
+				"supportsCheckpointRequests": {
+					"type": "boolean",
+					"description": "The debug adapter supports the checkpoint-type requests (`CreateCheckpointRequest`, `DeleteCheckpointRequest` and `LoadCheckpointRequest`)."
 				}
 			}
 		},

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@ layout: default
             <h1 class="text-center"><i class="fas fa-book" aria-hidden="true"></i></h1>
             <a href='{{ "/specification" | prepend: site.baseurl }}'><h3 class="text-center">Specification</h3></a>
             <p>
-                The latest version of the protocol specification is version 1.60.0.
+                The latest version of the protocol specification is version 1.61.0.
             </p>
             <p>
                 <a href='{{ "/changelog" | prepend: site.baseurl }}'>Change History</a>

--- a/specification.md
+++ b/specification.md
@@ -3217,6 +3217,103 @@ interface DisassembleResponse extends Response {
 }
 ```
 
+### <a name="Requests_CreateCheckpoint" class="anchor"></a>:leftwards_arrow_with_hook: CreateCheckpoint Request
+
+Creates an identical copy of the process.
+
+Clients should only call this request if the corresponding capability `supportsCheckpointRequests` is true.
+
+```typescript
+interface CreateCheckpointRequest extends Request {
+  command: 'createCheckpoint';
+}
+```
+
+Response to `createCheckpoint` request.
+
+<a name="Types_CreateCheckpointResponse" class="anchor"></a>
+```typescript
+interface CreateCheckpointResponse extends Response {
+  body?: {
+    /**
+     * The newly created checkpoint ID.
+     */
+    checkpointId: number;
+  };
+}
+```
+
+### <a name="Requests_DeleteCheckpoint" class="anchor"></a>:leftwards_arrow_with_hook: DeleteCheckpoint Request
+
+Deletes the checkpoint with the ID provided.
+
+Clients should only call this request if the corresponding capability `supportsCheckpointRequests` is true.
+
+```typescript
+interface DeleteCheckpointRequest extends Request {
+  command: 'deleteCheckpoint';
+
+  arguments: CheckpointArguments;
+}
+```
+
+Response to `deleteCheckpoint` request.
+
+<a name="Types_DeleteCheckpointResponse" class="anchor"></a>
+```typescript
+interface DeleteCheckpointResponse extends Response {
+  body?: {
+    /**
+     * True if the ID of the checkpoint requested for deletion existed and was
+     * successfully deleted, False otherwise.
+     */
+    success: boolean;
+  };
+}
+```
+
+### <a name="Requests_LoadCheckpoint" class="anchor"></a>:leftwards_arrow_with_hook: LoadCheckpoint Request
+
+Loads the checkpoint with the ID provided.
+
+Clients should only call this request if the corresponding capability `supportsCheckpointRequests` is true.
+
+```typescript
+interface LoadCheckpointRequest extends Request {
+  command: 'loadCheckpoint';
+
+  arguments: CheckpointArguments;
+}
+```
+
+Response to `loadCheckpoint` request.
+
+<a name="Types_LoadCheckpointResponse" class="anchor"></a>
+```typescript
+interface LoadCheckpointResponse extends Response {
+  body?: {
+    /**
+     * True if the ID of the checkpoint requested for deletion existed and was
+     * successfully loaded, False otherwise.
+     */
+    success: boolean;
+  };
+}
+```
+
+### <a name="Requests_CheckpointArguments" class="anchor"></a>CheckpointArguments
+
+Arguments for `deleteCheckpoint` and `loadCheckpoint` requests.
+
+```typescript
+interface CheckpointArguments {
+  /**
+   * ID of the checkpoint refered to by the request.
+   */
+  checkpointId: number;
+}
+```
+
 ## <a name="Types" class="anchor"></a>Types
 
 ### <a name="Types_Capabilities" class="anchor"></a>Capabilities
@@ -3439,6 +3536,13 @@ interface Capabilities {
    * `stepBack`).
    */
   supportsSingleThreadExecutionRequests?: boolean;
+
+  /**
+   * The debug adapter supports the checkpoint-type requests
+   * (`CreateCheckpointRequest`, `DeleteCheckpointRequest` and
+   * `LoadCheckpointRequest`).
+   */
+  supportsCheckpointRequests?: boolean;
 }
 ```
 


### PR DESCRIPTION
Hi, I would like to present this PR to add support in the DAP for Checkpoints. The use case I find for this feature are [GDB's Checkpoints](https://sourceware.org/gdb/onlinedocs/gdb/Checkpoint_002fRestart.html).

I'm working on a PR for [microsoft/vscode-cpptools](https://github.com/microsoft/vscode-cpptools) to add GUI support for Checkpoints in GDB. I have it working using an `EvaluateRequest` but it would be ideal to use a standard DAP request instead. If this PR goes ahead I'll add the subsequent PR on [microsoft/MIEngine](https://github.com/microsoft/MIEngine) to make use of it 🙂 