### PR TITLE
Document neovim support by the vimspector implementor

### DIFF
--- a/_implementors/tools.md
+++ b/_implementors/tools.md
@@ -16,7 +16,7 @@ The following table lists the known development tools (IDEs) that implement the 
 | Eclipse IDE (LSP4E connector) | lsp4e.debug  | Eclipse    | [Eclipse community](https://projects.eclipse.org/projects/technology.lsp4e/who), [Eclipse LSP4E](https://projects.eclipse.org/projects/technology.lsp4e)
 | Emacs                         | emacs.dap-mode | [@yyoncho](https://github.com/yyoncho) | [dap-mode](https://github.com/yyoncho/dap-mode)
 | Theia                         | Theia        | Eclipse    | [theia](https://github.com/theia-ide/theia/)
-| Vim                           | vimspector   | [Ben Jackson](https://github.com/puremourning) | [vimspector](https://github.com/puremourning/vimspector), [vim](https://github.com/vim/vim)
+| Vim, Neovim                   | vimspector   | [Ben Jackson](https://github.com/puremourning) | [vimspector](https://github.com/puremourning/vimspector), [vim](https://github.com/vim/vim), [neovim](https://github.com/neovim/neovim)
 | Neovim                        | neovim       | [@mfussenegger](https://github.com/mfussenegger) | [nvim-dap](https://github.com/mfussenegger/nvim-dap), [neovim](https://github.com/neovim/neovim)
 | Cloud Studio                  | cloudstudio  | [CODING](https://studio.dev.tencent.com/) 
 | JCIDE                         | JCIDE        | [JavaCardOS](https://www.javacardos.com/)   | [JCIDE](https://www.javacardos.com/tools)


### PR DESCRIPTION
At the time that `vimspector` was added to the implementors list, it only supported the `vim` editor.  It now also supports the `neovim` `vim` fork as documented at: https://github.com/puremourning/vimspector#dependencies