### PR TITLE
Add NAME Debug Adapter

### DIFF
--- a/_implementors/adapters.md
+++ b/_implementors/adapters.md
@@ -57,6 +57,7 @@ Many adapters publish releases tailored for specific editors, such as VS Code, a
 [Lua Debug](https://github.com/actboy168/lua-debug)|[@actboy168](https://github.com/actboy168)|[VS Code](https://marketplace.visualstudio.com/items?itemName=actboy168.lua-debug)
 [Mock Debug](https://github.com/Microsoft/vscode-mock-debug)|[@roblourens](https://github.com/roblourens)|[VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.mock-debug)
 [Mono Debug](https://github.com/Microsoft/vscode-mono-debug)|[@akoeplinger](https://github.com/akoeplinger)|[VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.mono-debug)
+[NAME](https://github.com/utdscheld/name)|[John Cole](https://personal.utdallas.edu/~John.Cole/)|
 [NativeScript](https://github.com/NativeScript/nativescript-vscode-extension/)|[@ivanbuhov](https://github.com/ivanbuhov)|[VS Code](https://marketplace.visualstudio.com/items?itemName=Telerik.nativescript)
 [Node Debug](https://github.com/Microsoft/vscode-node-debug)|[@weinand](https://github.com/weinand)|
 [OCaml Earlybird](https://github.com/hackwaly/ocamlearlybird)|[@sim642](https://github.com/sim642)|[VS Code](https://marketplace.visualstudio.com/items?itemName=ocamllabs.ocaml-platform)


### PR DESCRIPTION
The NAME emulator is a project sponsored by the [University of Texas at Dallas](utdallas.edu), more specifically by the professor [John Cole](https://personal.utdallas.edu/~John.Cole/). It aims to implement a MIPS emulator used by students to learn about computer architecture.

To my knowledge this is the first practical DAP server written in Rust, made possible thanks to the [dap-rs crate](https://github.com/sztomi/dap-rs). 

The code is continuing to evolve and we have not yet released the extension to the VS Code marketplace. However, I believe it is sufficiently instructive on the subject of DAP to be presentable on the DAP implementers page today.