### PR TITLE
Add deemphasize as presentationHint of a stack frame

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -3573,8 +3573,8 @@
 				},
 				"presentationHint": {
 					"type": "string",
-					"enum": [ "normal", "label", "subtle" ],
-					"description": "A hint for how to present this frame in the UI.\nA value of `label` can be used to indicate that the frame is an artificial frame that is used as a visual label or separator. A value of `subtle` can be used to change the appearance of a frame in a 'subtle' way."
+					"enum": [ "normal", "label", "subtle", "deemphasize" ],
+					"description": "A hint for how to present this frame in the UI.\nA value of `label` can be used to indicate that the frame is an artificial frame that is used as a visual label or separator. A value of `subtle` can be used to change the appearance of a frame in a 'subtle' way.\nA value of `deemphasize` can be used to indicate that the frame is skipped on stepping."
 				}
 			},
 			"required": [ "id", "name", "line", "column" ]


### PR DESCRIPTION
The goal of this PR is to make it possible to deemphasize a single frame in the call stack, instead of the entire source of that frame. This is particularly useful when the smart step skips a single frame in a source file and not the subsequent steps in the same file.

Note that this is already supported by VSCode [here](https://github.com/microsoft/vscode/blob/bde8a224911ff616a5a015a5ba6e78f503f35092/src/vs/workbench/contrib/debug/browser/callStackView.ts#L928) and advertised [here](https://github.com/microsoft/vscode/issues/25148#issuecomment-297823268) by @weinand . Also @isidorn suggested [here](https://github.com/microsoft/vscode/issues/65025#issuecomment-457532120)  to make it part of the protocol.