### PR TITLE
Add `bytes` and `asAddress` properties to the `DataBreakpointInfo` request

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ sectionid: changelog
 
 #### All notable changes to the specification will be documented in this file.
 
+* 1.66.x
+ * Add `bytes` and `asAddress` properties to the `DataBreakpointInfo` request
+
 * 1.65.x
   * Clarify handling of multiple filters in the `SetExceptionBreakpoints` request
   * Clarify lifetimes of objects created outside of suspended states

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -1458,11 +1458,19 @@
 				},
 				"name": {
 					"type": "string",
-					"description": "The name of the variable's child to obtain data breakpoint information for.\nIf `variablesReference` isn't specified, this can be an expression."
+					"description": "The name of the variable's child to obtain data breakpoint information for.\nIf `variablesReference` isn't specified, this can be an expression, or an address if `asAddress` is also true."
 				},
 				"frameId": {
 					"type": "integer",
 					"description": "When `name` is an expression, evaluate it in the scope of this stack frame. If not specified, the expression is evaluated in the global scope. When `variablesReference` is specified, this property has no effect."
+				},
+				"bytes": {
+					"type": "integer",
+					"description": "Clients may set this property only if the `supportsDataBreakpointBytes`\ncapability is true.\n\nClients may pass this to request a reference to a range of memory rather\nthan a single address. Data breakpoints set using the resulting data ID\nrequest that the debugger pause within the range of memory extending\n`bytes` from the address or variable specified by `name`."
+				},
+				"asAddress": {
+					"type": "boolean",
+					"description": "If `true`, the `name` is a memory address and the debugger should interpret it as a decimal value, or hex value if it is prefixed with `0x`.\n\nClients may set this property only if the `supportsDataBreakpointBytes`\ncapability is true."
 				},
 				"mode": {
 					"type": "string",
@@ -3235,6 +3243,10 @@
 				"supportsSingleThreadExecutionRequests": {
 					"type": "boolean",
 					"description": "The debug adapter supports the `singleThread` property on the execution requests (`continue`, `next`, `stepIn`, `stepOut`, `reverseContinue`, `stepBack`)."
+				},
+				"supportsDataBreakpointBytes": {
+					"type": "boolean",
+					"description": "The debug adapter supports the `asAddress` and `bytes` fields in the `dataBreakpointInfo` request."
 				},
 				"breakpointModes": {
 					"type": "array",

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -1466,7 +1466,7 @@
 				},
 				"bytes": {
 					"type": "integer",
-					"description": "Clients may set this property only if the `supportsDataBreakpointBytes`\ncapability is true.\n\nClients may pass this to request a reference to a range of memory rather\nthan a single address. Data breakpoints set using the resulting data ID\nrequest that the debugger pause within the range of memory extending\n`bytes` from the address or variable specified by `name`."
+					"description": "If specified, a the debug adapter should return information for the range of memory extending `bytes` number of bytes from the address or variable specified by `name`. Breakpoints set using the resulting data ID should pause on data access anywhere within that range.\n\nClients may set this property only if the `supportsDataBreakpointBytes` capability is true."
 				},
 				"asAddress": {
 					"type": "boolean",

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -1466,7 +1466,7 @@
 				},
 				"bytes": {
 					"type": "integer",
-					"description": "If specified, a the debug adapter should return information for the range of memory extending `bytes` number of bytes from the address or variable specified by `name`. Breakpoints set using the resulting data ID should pause on data access anywhere within that range.\n\nClients may set this property only if the `supportsDataBreakpointBytes` capability is true."
+					"description": "If specified, a debug adapter should return information for the range of memory extending `bytes` number of bytes from the address or variable specified by `name`. Breakpoints set using the resulting data ID should pause on data access anywhere within that range.\n\nClients may set this property only if the `supportsDataBreakpointBytes` capability is true."
 				},
 				"asAddress": {
 					"type": "boolean",

--- a/specification.md
+++ b/specification.md
@@ -1572,7 +1572,8 @@ interface DataBreakpointInfoArguments {
 
   /**
    * The name of the variable's child to obtain data breakpoint information for.
-   * If `variablesReference` isn't specified, this can be an expression.
+   * If `variablesReference` isn't specified, this can be an expression, or an
+   * address if `asAddress` is also true.
    */
   name: string;
 
@@ -1582,6 +1583,26 @@ interface DataBreakpointInfoArguments {
    * `variablesReference` is specified, this property has no effect.
    */
   frameId?: number;
+
+  /**
+   * Clients may set this property only if the `supportsDataBreakpointBytes`
+   * capability is true.
+   * 
+   * Clients may pass this to request a reference to a range of memory rather
+   * than a single address. Data breakpoints set using the resulting data ID
+   * request that the debugger pause within the range of memory extending
+   * `bytes` from the address or variable specified by `name`.
+   */
+  bytes?: number;
+
+  /**
+   * If `true`, the `name` is a memory address and the debugger should interpret
+   * it as a decimal value, or hex value if it is prefixed with `0x`.
+   * 
+   * Clients may set this property only if the `supportsDataBreakpointBytes`
+   * capability is true.
+   */
+  asAddress?: boolean;
 
   /**
    * The mode of the desired breakpoint. If defined, this must be one of the
@@ -3472,6 +3493,12 @@ interface Capabilities {
    * `stepBack`).
    */
   supportsSingleThreadExecutionRequests?: boolean;
+
+  /**
+   * The debug adapter supports the `asAddress` field in the
+   * `dataBreakpointInfo` request.
+   */
+  supportsDataBreakpointBytes?: boolean;
 
   /**
    * Modes of breakpoints supported by the debug adapter, such as 'hardware' or


### PR DESCRIPTION
A second approach.

Closes #455