### PR TITLE
fix: clarify how StackTraceArguments.format applies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ sectionid: changelog
 
 #### All notable changes to the specification will be documented in this file.
 
+* 1.70.x
+  * Clarify how `StackTraceArguments.format` applies
+
 * 1.69.x
   * Clarify the flow diagram to start a debug session
   * Add `supportsANSIStyling` capabilities to allow colorization of text from debug adapters

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -2033,7 +2033,7 @@
 				},
 				"format": {
 					"$ref": "#/definitions/StackFrameFormat",
-					"description": "Specifies details on how to format the stack frames.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsValueFormattingOptions` is true."
+					"description": "Specifies details on how to format the returned `StackFrame.name`. The debug adapter may format requested details in any way that would make sense to a developer.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsValueFormattingOptions` is true."
 				}
 			},
 			"required": [ "threadId" ]

--- a/specification.md
+++ b/specification.md
@@ -2222,7 +2222,9 @@ interface StackTraceArguments {
   levels?: number;
 
   /**
-   * Specifies details on how to format the stack frames.
+   * Specifies details on how to format the returned `StackFrame.name`. The
+   * debug adapter may format requested details in any way that would make sense
+   * to the developer.
    * The attribute is only honored by a debug adapter if the corresponding
    * capability `supportsValueFormattingOptions` is true.
    */


### PR DESCRIPTION
Closes #411