### PR TITLE
fix: clarify `ContinuedEvent.allThreadsContinued`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ sectionid: changelog
 
 * 1.70.x
   * Clarify how `StackTraceArguments.format` applies
+  * Clarify the default behavior of `ContinuedEvent.allThreadsContinued`
 
 * 1.69.x
   * Clarify the flow diagram to start a debug session

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -249,7 +249,7 @@
 							},
 							"allThreadsContinued": {
 								"type": "boolean",
-								"description": "If `allThreadsContinued` is true, a debug adapter can announce that all threads have continued."
+								"description": "If omitted or set to `true`, this event signals to the client that all threads have been resumed. The value `false` indicates that not all threads were resumed."
 							}
 						},
 						"required": [ "threadId" ]
@@ -1673,7 +1673,7 @@
 						"properties": {
 							"allThreadsContinued": {
 								"type": "boolean",
-								"description": "The value true (or a missing property) signals to the client that all threads have been resumed. The value false indicates that not all threads were resumed."
+								"description": "If omitted or set to `true`, this response signals to the client that all threads have been resumed. The value `false` indicates that not all threads were resumed."
 							}
 						}
 					}


### PR DESCRIPTION
Fixes #513