### PR TITLE
chore: rev version to 1.69

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@ layout: default
             <h1 class="text-center"><i class="fas fa-book" aria-hidden="true"></i></h1>
             <a href='{{ "/specification" | prepend: site.baseurl }}'><h3 class="text-center">Specification</h3></a>
             <p>
-                The latest version of the protocol specification is version 1.64.0.
+                The latest version of the protocol specification is version 1.69.0.
             </p>
             <p>
                 <a href='{{ "/changelog" | prepend: site.baseurl }}'>Change History</a>


### PR DESCRIPTION
This pull request updates https://microsoft.github.io/debug-adapter-protocol/ to show the correct current version.