### PR TITLE
Add Squirrel Debugger to adapters.md

### DIFF
--- a/_implementors/adapters.md
+++ b/_implementors/adapters.md
@@ -80,6 +80,7 @@ Many adapters publish releases tailored for specific editors, such as VS Code, a
 [Ruby Byebug (VSCode)](https://gitlab.com/firelizzard/vscode-byebug)|[Ethan Reesor](https://gitlab.com/firelizzard)|[VS Code](https://marketplace.visualstudio.com/items?itemName=ethan-reesor.vscode-byebug)
 [Rust (for embedded)](https://github.com/probe-rs/vscode)|[probe.rs community](https://github.com/probe-rs)|[VS Code](https://probe.rs/docs/tools/vscode/), [Eclipse](https://marketplace.eclipse.org/content/eclipse-corrosion-rust-editing-and-debugging)
 [Scala](https://github.com/scalacenter/scala-debug-adapter)|[@adpi2](https://github.com/adpi2)|[SBT](https://index.scala-lang.org/scalacenter/scala-debug-adapter)
+[Squirrel](https://github.com/samisalreadytaken/sqdbg)|[@samisalreadytaken](https://github.com/samisalreadytaken)|
 [SWI-Prolog](https://github.com/eshelyaron/debug_adapter)|[@eshelyaron](https://github.com/eshelyaron)|[SWI and Emacs](https://github.com/eshelyaron/debug_adapter#installation)
 [SWF](https://github.com/BowlerHatLLC/vscode-nextgenas)|[@joshtynjala](https://github.com/joshtynjala)|[VS Code](https://marketplace.visualstudio.com/items?itemName=bowlerhatllc.vscode-nextgenas)
 [TLA+](https://github.com/tlaplus/vscode-tlaplus)|[@lemmy](https://github.com/lemmy)|[VS Code](https://marketplace.visualstudio.com/items?itemName=alygin.vscode-tlaplus-nightly)


### PR DESCRIPTION
It's a debugger using DAP, and it implements most DAP features. Usage field is empty because re-linking the readme seems redundant.