### PR TITLE
fix: clarify representation of breakpoint after changed event

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ sectionid: changelog
 * 1.70.x
   * Clarify how `StackTraceArguments.format` applies
   * Clarify the default behavior of `ContinuedEvent.allThreadsContinued`
+  * Clarify representation of breakpoints after a `changed` event
 
 * 1.69.x
   * Clarify the flow diagram to start a debug session

--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -408,7 +408,7 @@
 		"BreakpointEvent": {
 			"allOf": [ { "$ref": "#/definitions/Event" }, {
 				"type": "object",
-				"description": "The event indicates that some information about a breakpoint has changed.",
+				"description": "The event indicates that some information about a breakpoint has changed. While debug adapters may notify the clients of `changed` breakpoints using this event, clients should continue to use the breakpoint's original properties when updating a source's breakpoints in the `breakpoint` request.",
 				"properties": {
 					"event": {
 						"type": "string",

--- a/overview.md
+++ b/overview.md
@@ -179,7 +179,7 @@ After the response to `configurationDone` is sent, the debug adapter may respond
 
 The following sequence diagram summarizes the sequence of requests and events for a hypothetical _gdb_ debug adapter:
 
-<img src="./img/init-launch.svg" width="100%">
+<img src="./img/init-launch.svg" width="100%" alt="Sequence diagram of the launch flow">
 
 ### Stopping and accessing debuggee state
 
@@ -233,7 +233,7 @@ If the debuggee has ended (and the debug adapter is able to detect this), an opt
 
 This diagram summarizes the sequence of request and events for a hypothetical debug adapter for _gdb_:
 
-<img src="./img/stop-continue-terminate.svg" width="100%" />
+<img src="./img/stop-continue-terminate.svg" width="100%" alt="Sequence diagram of the termination flow" />
 
 ## Libraries (SDKs) for DAP providers and consumers
 


### PR DESCRIPTION
Fixes #545

Aside from existing discussion, I think this is a good change because
it avoids race conditions if a DA adjusts a breakpoint concurrently
while the client updates those breakpoints (precipitated either via
network latency or just processing latency on either end.)