### PR TITLE
clarify: completion trigger characters

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -3226,7 +3226,7 @@
 					"items": {
 						"type": "string"
 					},
-					"description": "The set of characters that should trigger completion in a REPL. If not specified, the UI should assume the `.` character."
+					"description": "The set of characters that should automatically trigger a completion request in a REPL. If not specified, the client should assume the `.` character. The client may trigger additional completion requests on characters such as ones that make up common identifiers, or as otherwise requested by a user."
 				},
 				"supportsModulesRequest": {
 					"type": "boolean",


### PR DESCRIPTION
Closes https://github.com/microsoft/debug-adapter-protocol/issues/547