### PR TITLE
Added debugConsoleMode to StartDebuggingRequestArguments

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -848,6 +848,14 @@
 					"additionalProperties": true,
 					"description": "Arguments passed to the new debug session. The arguments must only contain properties understood by the `launch` or `attach` requests of the debug adapter and they must not contain any client-specific properties (e.g. `type`) or client-specific features (e.g. substitutable 'variables')."
 				},
+				"debugConsoleMode": {
+					"type": "string",
+					"enum": [
+						"separate",
+						"mergeWithParent"
+					],
+					"description": "Specifies if a new debug console window should be created or the output should be merged with the parent session's console."
+				},
 				"request": {
 					"type": "string",
 					"enum": [


### PR DESCRIPTION
I am working on creating improved multi-process support for a VSCode gdb debugger extension. (Afaik this is the first extension to successfully debug multiple native subprocesses) To do this, I used the StartDebuggingRequest to start new debugging sessions for each subprocesses detected by gdb to redirect VSCode protocol messages to the specific subprocess.

However, for this use case, no new gdb sessions are actually started because gdb debugs subprocesses the itself. Therefore, I would like to propose the ability to request that child debug sessions can have their debug output windows merged with the parent. 

<img width="1579" height="505" alt="image" src="https://github.com/user-attachments/assets/424a94ad-0964-4abe-91f7-a3c3e527df60" />


In VSCode, this capability has already been implemented in https://github.com/microsoft/vscode/pull/80673, it only needs to be exposed in DAP. Once this PR has been released, I can open a PR in VSCode to actually respect the debugConsoleMode option.

Please let me know what you think of this addition.

Closes https://github.com/microsoft/debug-adapter-protocol/issues/575