### PR TITLE
fix: rename new debugConsoleMode

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -849,13 +849,13 @@
 					"additionalProperties": true,
 					"description": "Arguments passed to the new debug session. The arguments must only contain properties understood by the `launch` or `attach` requests of the debug adapter and they must not contain any client-specific properties (e.g. `type`) or client-specific features (e.g. substitutable 'variables')."
 				},
-				"debugConsoleMode": {
+				"outputPresentation": {
 					"type": "string",
 					"enum": [
 						"separate",
 						"mergeWithParent"
 					],
-					"description": "Specifies if a new debug console window should be created or the output should be merged with the parent session's console."
+					"description": "Hints whether output of the child sessions should be presented separately or merged with that of the parent session's."
 				},
 				"request": {
 					"type": "string",


### PR DESCRIPTION
The 'debug console' is not a protocol-level concept in DAP. Instead have this verbiage refer to the presentation of output events which is more aligned with what the protocol knows about.