### PR TITLE
Add ZIL debug adapter to implementations table

### DIFF
--- a/_implementors/adapters.md
+++ b/_implementors/adapters.md
@@ -92,6 +92,7 @@ Many adapters publish releases tailored for specific editors, such as VS Code, a
 [VDM-SL, VDM++, VDM-RT](https://github.com/nickbattle/vdmj/tree/master/lsp)|[@nickbattle](https://github.com/nickbattle)|[VS Code](https://marketplace.visualstudio.com/items?itemName=jonaskrask.vdm-vscode)
 [VSCode rdbg Ruby Debugger](https://github.com/ruby/vscode-rdbg)|[@ko1](https://github.com/ko1)|[VS Code](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg)
 [Wolfram Language](https://github.com/kenkangxgwe/lsp-wl?tab=readme-ov-file#debug-adapter-features)|[@kenkangxgwe](https://github.com/kenkangxgwe/lsp-wl)|[VS Code](https://marketplace.visualstudio.com/items?itemName=lsp-wl.lsp-wl-client)
+[ZIL](https://foss.heptapod.net/zilf/vscode-zil-language)|[@taradinoc](https://github.com/taradinoc)|[VS Code](https://marketplace.visualstudio.com/items?itemName=zilf.zil-language)
 {: .table .table-bordered .table-responsive}
 
 *If you are missing a debug adapter implementation please create a pull request in GitHub against this markdown [document](https://github.com/Microsoft/debug-adapter-protocol/blob/main/_implementors/adapters.md)*


### PR DESCRIPTION
The ZIL language extension for VS Code includes an implementation of the DAP.