### PR TITLE
add Kate to implementors list

### DIFF
--- a/_implementors/tools.md
+++ b/_implementors/tools.md
@@ -25,6 +25,7 @@ The following table lists the known development tools (IDEs) that implement the 
 | OpenSumi                      | OpenSumi     | [OpenSumi](https://github.com/opensumi)   | [opensumi/core](https://github.com/opensumi/core)
 | IntelliJ (LSP4IJ DAP support) | lsp4ij.debug | Red Hat    | [IntelliJ LSP4IJ](https://github.com/redhat-developer/lsp4ij/blob/main/docs/dap/UserGuide.md) |
 | Zed                           | zed          | Zed Industries | [zed](https://github.com/zed-industries/zed) |
+| Kate                          |              | KDE        | [Kate](https://invent.kde.org/utilities/kate) |
 {: .table .table-bordered .table-responsive}
 
 The "client ID" is the identifier that a development tool sends to the debug adapter as part of the [**initialize**](../../specification#Requests_Initialize) request.


### PR DESCRIPTION
Kate seems to not specify the clientID: https://invent.kde.org/utilities/kate/-/blob/dfc22bdb89aeeae7821aac0ded1cc4224d92a8b0/addons/gdbplugin/dap/client.cpp#L564