### PR TITLE
Add binary and octal support to ValueFormat

### DIFF
--- a/debugAdapterProtocol.json
+++ b/debugAdapterProtocol.json
@@ -4369,6 +4369,14 @@
 				"hex": {
 					"type": "boolean",
 					"description": "Display the value in hex."
+				},
+				"binary": {
+					"type": "boolean",
+					"description": "Display the value in binary."
+				},
+				"octal": {
+					"type": "boolean",
+					"description": "Display the value in octal."
 				}
 			}
 		},


### PR DESCRIPTION
Add binary and octal support to ValueFormat

Good day,

This PR adds binary and octal formatting options to the ValueFormat type, addressing the feature request in issue #599.

## Changes
- Added `binary` property: display values in binary (base-2) format
- Added `octal` property: display values in octal (base-8) format

These additions allow debug adapters to format values in more numeric bases, complementing the existing `hex` (base-16) support.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof