### PR TITLE
Add DAP Proxies and Utilities implementors page

### DIFF
--- a/_implementors/proxies.md
+++ b/_implementors/proxies.md
@@ -1,0 +1,17 @@
+---
+layout: implementors
+title:  "DAP Proxies and Utilities"
+shortTitle: "Proxies"
+author: Microsoft
+index: 4
+---
+
+The following table lists known tools that route, multiplex, or observe the Debug Adapter Protocol — tools that sit between adapters and clients to enable scenarios beyond what a single point-to-point DAP connection supports.
+
+| Tool | Description | Maintainer |
+|------|-------------|------------|
+[dap-mux](https://github.com/dap-mux/dap-mux)|DAP multiplexer — connects multiple clients (editors, REPLs) to a single debug adapter session simultaneously, with session persistence and late-join state replay|[@wolf](https://github.com/wolf)
+[dap-observer](https://github.com/shaleh/dap-observer)|Read-only DAP client that connects to a running dap-mux session and renders the current stack frame's variables as a navigable terminal tree|[@shaleh](https://github.com/shaleh)
+{: .table .table-bordered .table-responsive}
+
+*If you are missing a DAP proxy or utility please create a pull request in GitHub against this markdown [document](https://github.com/Microsoft/debug-adapter-protocol/blob/main/_implementors/proxies.md)*


### PR DESCRIPTION
## A new category for the DAP ecosystem

The three existing implementors pages cover the obvious cases: adapters that wrap debuggers, editors that speak DAP as a client, and libraries for building either. But there's a fourth kind of thing emerging — tools that sit *between* adapters and clients, routing or multiplexing the protocol without being either one.

[dap-mux](https://github.com/dap-mux/dap-mux) is the first entry in a new page I'm proposing for exactly this category.

## What dap-mux does

dap-mux is a DAP proxy. It sits between a debug adapter and multiple clients, so you can connect your editor and a REPL to the same debug session simultaneously. Both clients are first-class — either can set breakpoints, step, evaluate expressions. A client that joins late gets the current session state replayed to it immediately.

This isn't a feature any adapter or editor is positioned to provide. It's infrastructure for composing DAP tools freely — any editor, any language, any adapter.

## Why a new page, not an existing one

dap-mux isn't a debug adapter — its own README says so explicitly. It doesn't belong in the adapters list any more than a load balancer belongs in a list of web servers. The tools and SDKs pages don't fit either.

The right answer is a new category: tools that route, multiplex, or observe DAP traffic. I've called it "Proxies and Utilities."

## The ecosystem is already growing

[@shaleh](https://github.com/shaleh) has built [dap-observer](https://github.com/shaleh/dap-observer), a read-only DAP client that connects to a running dap-mux session and renders the current frame's variables as a navigable terminal tree. It's already the second entry on the new page.

Two tools in this space within the first month of dap-mux being public. The category is real and worth having a home in the implementors section.